### PR TITLE
Added image pruning scheduled job

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repo contains a set of general _good practice_ jobs that can be used as a starting point for operationalizing an OpenShift Container Platform cluster. This repo breaks down into several categories:
 
-- *Cron Jobs* - a set of _CronJob_ (_ScheduledJob_ before OCP 3.4) templates for common scheduled tasks
+- *jobs* - a set of _jobs_(including _CronJob_ [_ScheduledJob_ before OCP 3.4]) templates for common tasks

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,32 @@
+# Jobs
+
+This directory contains a collection of [jobs](https://docs.openshift.com/container-platform/latest/dev_guide/jobs.html) and [scheduled jobs](https://docs.openshift.com/container-platform/latest/dev_guide/scheduled_jobs.html).
+
+The rest of this document describes the specific configurations that are applicable to the execution of certain jobs contained within this directory.
+
+### [scheduledjob-prune-images.json](scheduledjob-prune-images.json)
+
+Executes [image pruning](https://docs.openshift.com/container-platform/latest/admin_guide/pruning_resources.html#pruning-images) of the integrated docker registry on a regular basis.
+
+Prior to instantiating the template, the following must be completed within a project:
+
+1. Create a new service account
+
+	```
+	oc create serviceaccount pruner`
+	```
+
+2. Grant cluster *edit* permissions on the service account created previously (requires elevated rights)
+
+	```
+	oc adm policy add-cluster-role-to-user edit system:serviceaccount:<project-name>:pruner`
+	```
+
+Instantiate the template
+
+```
+oc process -v= JOB_SERVICE_ACCOUNT=pruner -f scheduledjob-prune-images.json | oc create -f-
+```
+
+
+

--- a/jobs/scheduledjob-prune-images.json
+++ b/jobs/scheduledjob-prune-images.json
@@ -1,0 +1,99 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "scheduledjob-prune-images",
+        "annotations": {
+            "description": "Scheduled Task to Prune Images from Internal Docker Registry",
+            "iconClass": "icon-shadowman",
+            "tags": "management,scheduledjob,prune,images"
+        }
+    },
+    "objects": [
+    {
+        "kind": "ScheduledJob",
+        "apiVersion": "batch/v2alpha1",
+        "metadata": {
+            "name": "${JOB_NAME}"
+        },
+        "spec": {
+            "schedule": "${SCHEDULE}",
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "${JOB_NAME}",
+                                    "image": "openshift3/jenkins-slave-base-rhel7",
+                                    "command": [
+                                        "/bin/bash",
+                                        "-c",
+                                        "oc adm prune images --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm"
+                                    ],
+                                    "env": [
+                                        {
+                                            "name": "IMAGE_PRUNE_KEEP_TAG_REVISIONS",
+                                            "value": "${IMAGE_PRUNE_KEEP_TAG_REVISIONS}"
+                                        },
+                                        {
+                                            "name": "IMAGE_PRUNE_KEEP_YOUNGER_THAN",
+                                            "value": "1h0m0s"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "restartPolicy": "Never",
+                            "terminationGracePeriodSeconds": 30,
+                            "activeDeadlineSeconds": 500,
+                            "dnsPolicy": "ClusterFirst",
+                            "serviceAccountName": "${JOB_SERVICE_ACCOUNT}",
+                            "serviceAccount": "${JOB_SERVICE_ACCOUNT}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ],
+    "parameters": [
+        {
+            "name": "JOB_NAME",
+            "displayName": "Job Name",
+            "description": "Name of the Scheduled Job to Create.",
+            "value": "scheduledjob-prune-images",
+            "required": true
+        },
+        {
+            "name": "SCHEDULE",
+            "displayName": "Cron Schedule",
+            "description": "Cron Schedule to Execute the Job",
+            "value": "0 * * * ?",
+            "required": true
+        },
+        {
+            "name": "JOB_SERVICE_ACCOUNT",
+            "displayName": "Service Account Name",
+            "description": "Name of the Service Account To Exeucte the Job As.",
+            "value": "default",
+            "required": true
+        },
+        {
+            "name": "IMAGE_PRUNE_KEEP_TAG_REVISIONS",
+            "displayName": "Number of Tag Revisions",
+            "description": "Specify the number of image revisions for a tag in an image stream that will be preserved.",
+            "value": "3",
+            "required": true
+        },
+        {
+            "name": "IMAGE_PRUNE_KEEP_YOUNGER_THAN",
+            "displayName": "Minimum Age of an Image",
+            "description": "The minimum age of an image for it to be considered a candidate for pruning",
+            "value": "1h0m0s",
+            "required": true
+        }
+    ],
+    "labels": {
+        "template": "scheduledjob-prune-images"
+    }
+}


### PR DESCRIPTION
#### What is this PR About?
Initial implementation of the jobs folder. Added scheduled job to prune images from integrated docker registry

#### How do we test this?

1. Create a new service acccount

`oc create serviceaccount pruner`

2. Grant cluster *edit* permissions on service account created previously

`oc adm policy add-cluster-role-to-user edit pruner`

3. Instantiate template

Note: Specify a project of your choosing

`oc process -v= JOB_SERVICE_ACCOUNT=pruner -f jobs/scheduledjob-prune-images.json | oc create -f-`

cc: @redhat-cop/day-in-the-life-ops @etsauer 
