### PR TITLE
Improved image pruning scheduledjob and added scheduledjob to prune builds and deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repo contains a set of general _good practice_ jobs that can be used as a starting point for operationalizing an OpenShift Container Platform cluster. This repo breaks down into several categories:
 
-- *jobs* - a set of _jobs_(including _CronJob_ [_ScheduledJob_ before OCP 3.4]) templates for common tasks
+- *jobs* - a set of _jobs_ (including _ScheduledJob_) templates for common tasks

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -19,7 +19,7 @@ Prior to instantiating the template, the following must be completed within a pr
 2. Grant cluster *edit* permissions on the service account created previously (requires elevated rights)
 
 	```
-	oc adm policy add-cluster-role-to-user edit system:serviceaccount:<project-name>:pruner
+	oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:<project-name>:pruner
 	```
 
 Instantiate the template

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -4,29 +4,29 @@ This directory contains a collection of [jobs](https://docs.openshift.com/contai
 
 The rest of this document describes the specific configurations that are applicable to the execution of certain jobs contained within this directory.
 
-### [scheduledjob-prune-images.json](scheduledjob-prune-images.json)
+### Pruning Resources
 
-Executes [image pruning](https://docs.openshift.com/container-platform/latest/admin_guide/pruning_resources.html#pruning-images) of the integrated docker registry on a regular basis.
+The [scheduledjob-prune-images.json](scheduledjob-prune-images.json) facilitates [image pruning](https://docs.openshift.com/container-platform/latest/admin_guide/pruning_resources.html#pruning-images) of the integrated docker registry while the [scheduledjob-prune-builds-deployments.json](scheduledjob-prune-builds-deployments.json) facilitates pruning [builds](https://docs.openshift.com/container-platform/latest/admin_guide/pruning_resources.html#pruning-builds) and [deployments](https://docs.openshift.com/container-platform/latest/admin_guide/pruning_resources.html#pruning-deployments) on a regular basis.
 
 Prior to instantiating the template, the following must be completed within a project:
 
 1. Create a new service account
 
 	```
-	oc create serviceaccount pruner`
+	oc create serviceaccount pruner
 	```
 
 2. Grant cluster *edit* permissions on the service account created previously (requires elevated rights)
 
 	```
-	oc adm policy add-cluster-role-to-user edit system:serviceaccount:<project-name>:pruner`
+	oc adm policy add-cluster-role-to-user edit system:serviceaccount:<project-name>:pruner
 	```
 
 Instantiate the template
 
 ```
-oc process -v= JOB_SERVICE_ACCOUNT=pruner -f scheduledjob-prune-images.json | oc create -f-
+oc process -v=JOB_SERVICE_ACCOUNT=pruner -f <template_file> | oc create -f-
 ```
 
-
+*Note: Some templates require additional parameters to be specified. Be sure to review each specific template contents prior to instantiation*
 

--- a/jobs/scheduledjob-prune-builds-deployments.json
+++ b/jobs/scheduledjob-prune-builds-deployments.json
@@ -2,11 +2,11 @@
     "kind": "Template",
     "apiVersion": "v1",
     "metadata": {
-        "name": "scheduledjob-prune-images",
+        "name": "scheduledjob-prune-builds-deployments",
         "annotations": {
-            "description": "Scheduled Task to Prune Images from Internal Docker Registry",
+            "description": "Scheduled Task to Prune Builds or Deployments",
             "iconClass": "icon-shadowman",
-            "tags": "management,scheduledjob,prune,images"
+            "tags": "management,scheduledjob,prune,builds,deployments"
         }
     },
     "objects": [
@@ -32,16 +32,24 @@
                                     "command": [
                                         "/bin/bash",
                                         "-c",
-                                        "oc adm prune images --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm"
+                                        "oc adm prune ${PRUNE_TYPE} --keep-complete=$KEEP_COMPLETE --keep-failed=$KEEP_FAILED --keep-younger-than=$KEEP_YOUNGER_THAN --orphans=$PRUNE_ORPHANS --confirm"
                                     ],
                                     "env": [
                                         {
-                                            "name": "IMAGE_PRUNE_KEEP_TAG_REVISIONS",
-                                            "value": "${IMAGE_PRUNE_KEEP_TAG_REVISIONS}"
+                                            "name": "KEEP_COMPLETE",
+                                            "value": "${KEEP_COMPLETE}"
                                         },
                                         {
-                                            "name": "IMAGE_PRUNE_KEEP_YOUNGER_THAN",
-                                            "value": "${IMAGE_PRUNE_KEEP_YOUNGER_THAN}"
+                                            "name": "KEEP_FAILED",
+                                            "value": "${KEEP_FAILED}"
+                                        },
+                                        {
+                                            "name": "KEEP_YOUNGER_THAN",
+                                            "value": "${KEEP_YOUNGER_THAN}"
+                                        },
+                                        {
+                                            "name": "PRUNE_ORPHANS",
+                                            "value": "${PRUNE_ORPHANS}"
                                         }
                                     ]
                                 }
@@ -64,7 +72,7 @@
             "name": "JOB_NAME",
             "displayName": "Job Name",
             "description": "Name of the Scheduled Job to Create.",
-            "value": "scheduledjob-prune-images",
+            "value": "scheduledjob-prune-resources",
             "required": true
         },
         {
@@ -82,35 +90,42 @@
             "required": true
         },
         {
-            "name": "IMAGE_PRUNE_KEEP_TAG_REVISIONS",
-            "displayName": "Number of Tag Revisions",
-            "description": "Specify the number of image revisions for a tag in an image stream that will be preserved.",
-            "value": "3",
+            "name": "PRUNE_TYPE",
+            "displayName": "Type of pruning action (builds|deployments)",
+            "description": "Type of pruning action that will be performed. Must specify 'builds' or 'deployments'",
+            "value": "",
             "required": true
         },
         {
-            "name": "IMAGE_PRUNE_KEEP_YOUNGER_THAN",
-            "displayName": "Minimum Age of an Image",
-            "description": "The minimum age of an image for it to be considered a candidate for pruning",
-            "value": "1h0m0s",
-            "required": true
-        },
-        {
-            "name": "SUCCESS_JOBS_HISTORY_LIMIT",
-            "displayName": "Successful Job History Limit",
-            "description": "The number of successful jobs that will be retained",
+            "name": "KEEP_COMPLETE",
+            "displayName": "Number of Completed Items",
+            "description": "Number of completed items that will not be considered for pruning.",
             "value": "5",
             "required": true
         },
         {
-            "name": "FAILED_JOBS_HISTORY_LIMIT",
-            "displayName": "Failed Job History Limit",
-            "description": "The number of failed jobs that will be retained",
-            "value": "5",
+            "name": "KEEP_FAILED",
+            "displayName": "Number of Failed Items",
+            "description": "Number of failed items that will not be considered for pruning.",
+            "value": "1",
+            "required": true
+        },
+        {
+            "name": "KEEP_YOUNGER_THAN",
+            "displayName": "Minimum Age of the resource",
+            "description": "The minimum age of the resource for it to be considered a candidate for pruning",
+            "value": "60m",
+            "required": true
+        },
+        {
+            "name": "PRUNE_ORPHANS",
+            "displayName": "Prune orphan resources",
+            "description": "Prune builds or deployments where their associated BuildConfig or DeploymentConfig no longer exists",
+            "value": "true",
             "required": true
         }
     ],
     "labels": {
-        "template": "scheduledjob-prune-images"
+        "template": "scheduledjob-prune-builds-deployments"
     }
 }

--- a/jobs/scheduledjob-prune-builds-deployments.json
+++ b/jobs/scheduledjob-prune-builds-deployments.json
@@ -14,7 +14,7 @@
         "kind": "ScheduledJob",
         "apiVersion": "batch/v2alpha1",
         "metadata": {
-            "name": "${JOB_NAME}"
+            "name": "${JOB_NAME}-${PRUNE_TYPE}"
         },
         "spec": {
             "schedule": "${SCHEDULE}",
@@ -27,7 +27,7 @@
                         "spec": {
                             "containers": [
                                 {
-                                    "name": "${JOB_NAME}",
+                                    "name": "${JOB_NAME}-${PRUNE_TYPE}",
                                     "image": "openshift3/jenkins-slave-base-rhel7",
                                     "command": [
                                         "/bin/bash",
@@ -122,6 +122,20 @@
             "displayName": "Prune orphan resources",
             "description": "Prune builds or deployments where their associated BuildConfig or DeploymentConfig no longer exists",
             "value": "true",
+            "required": true
+        },
+        {
+            "name": "SUCCESS_JOBS_HISTORY_LIMIT",
+            "displayName": "Successful Job History Limit",
+            "description": "The number of successful jobs that will be retained",
+            "value": "5",
+            "required": true
+        },
+        {
+            "name": "FAILED_JOBS_HISTORY_LIMIT",
+            "displayName": "Failed Job History Limit",
+            "description": "The number of failed jobs that will be retained",
+            "value": "5",
             "required": true
         }
     ],


### PR DESCRIPTION
#### What is this PR About?
Adds scheduled job to prune builds and deployments

Note: `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` are not currently implemented in OCP, but will be in future release. Those fields are currently ignored

#### Trello Card?

https://trello.com/c/r4PUPlyi

#### How do we test this?
Add the template to the OpenShift cluster and instantiate the template. Additional information can be found in the README

cc: @redhat-cop/day-in-the-life-ops @etsauer @oybed 
