### PR TITLE
Ldap sync review

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -64,13 +64,14 @@ The `scheduledjob-ldap-group-sync` template creates several objects in OpenShift
 
 To instantiate the template, run the following.
 
-1. Create a project in which to host your jobs. Currently the template requires that it be created in a project called `cluster-ops`. This will become more flexible in future versions of OpenShift.
+1. Create a project in which to host your jobs.
 	```
-	oc new-project cluster-ops
+	oc new-project <project>
 	```
 2. Instantiate the template
 	```
 	oc process -f jobs/scheduledjob-ldap-group-sync.yml \
+	  -p NAMESPACE="<project name from previous step>"
 	  -p LDAP_URL="ldap://idm-2.etl.rht-labs.com:389" \
 	  -p LDAP_BIND_DN="uid=ldap-user,cn=users,cn=accounts,dc=myorg,dc=example,dc=com" \
 		-p LDAP_BIND_PASSWORD="password1" \

--- a/jobs/scheduledjob-ldap-group-sync.yml
+++ b/jobs/scheduledjob-ldap-group-sync.yml
@@ -108,7 +108,7 @@ objects:
   - kind: ServiceAccount
     name: ${JOB_SERVICE_ACCOUNT}
   userNames:
-  - system:serviceaccount:cluster-ops:${JOB_SERVICE_ACCOUNT}
+  - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
@@ -116,6 +116,10 @@ objects:
     labels:
       template: "scheduledjob-ldap-group-sync"
 parameters:
+  - name: "NAMESPACE"
+    displayName: "Namespace"
+    description: "Name of the Namespace where to deploy the Scheduled Job"
+    required: true
   - name: "JOB_NAME"
     displayName: "Job Name"
     description: "Name of the Scheduled Job to Create."


### PR DESCRIPTION
#### What is this PR About?
Remove the hardcoded namespace from ClusterRoleBinding object and add a new parameter to the template to manually select the project where this is deployed. This fits better with the openshift applier from CASL as well.

Once this merged please close issue #7 

#### How do we test this?
Follow the instructions from README

cc: @redhat-cop/day-in-the-life-ops
