### PR TITLE
Remove symbolic links to old cron job names

### DIFF
--- a/jobs/scheduledjob-ldap-group-sync.yml
+++ b/jobs/scheduledjob-ldap-group-sync.yml
@@ -1,1 +1,0 @@
-cronjob-ldap-group-sync.yml

--- a/jobs/scheduledjob-prune-builds-deployments.yml
+++ b/jobs/scheduledjob-prune-builds-deployments.yml
@@ -1,1 +1,0 @@
-cronjob-prune-builds-deployments.yml

--- a/jobs/scheduledjob-prune-images.yml
+++ b/jobs/scheduledjob-prune-images.yml
@@ -1,1 +1,0 @@
-cronjob-prune-images.yml


### PR DESCRIPTION
#### What is this PR About?
Remove symbolic links from cronjobs to scheduledjobs we did for testing

#### How do we test this?
Follow README

cc: @redhat-cop/day-in-the-life-ops
