### PR TITLE
Moving Docker source to official repo

### DIFF
--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -29,7 +29,7 @@ objects:
     runPolicy: Serial
     source:
       git:
-        uri: https://github.com/oybed/openshift-management.git
+        uri: https://github.com/redhat-cop/openshift-management.git
         ref: prune
       contextDir: /images/prune-ocp-projects
     strategy:


### PR DESCRIPTION
#### What is this PR About?
Moving the Docker source to reference `redhat-cop` instead of personal repo

#### How do we test this?
Deploy the cronjob to OpenShift

cc: @redhat-cop/day-in-the-life-ops
