### PR TITLE
Update cronjob-prune-builds-deployments.yml

### DIFF
--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -15,8 +15,8 @@ objects:
   spec:
     schedule: "${SCHEDULE}"
     concurrencyPolicy: Forbid
-    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
-    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    successfulJobsHistoryLimit: "${SUCCESS_JOBS_HISTORY_LIMIT}"
+    failedJobsHistoryLimit: "${FAILED_JOBS_HISTORY_LIMIT}"
     jobTemplate:
       spec:
         template:


### PR DESCRIPTION
#### What is this PR About?
Remove double curly braces for local variables such as "${{SUCCESS_JOBS_HISTORY_LIMIT}}"

#### How do we test this?
Provide commands/steps to test this PR.

cc: @redhat-cop/day-in-the-life-ops
