### PR TITLE
Create cronjob-ad-group-sync.yml

### DIFF
--- a/jobs/cronjob-ad-group-sync.yml
+++ b/jobs/cronjob-ad-group-sync.yml
@@ -1,0 +1,182 @@
+---
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "cronjob-ad-group-sync"
+  annotations:
+    description: "Scheduled Task to Perform Active Directory Group Synchronization"
+    iconClass: "icon-shadowman"
+    tags: "management,cronjob,activedirectory,group,sync"
+objects:
+- kind: ConfigMap
+  metadata:
+    name: ad-config
+    labels:
+      template: "cronjob-ad-group-sync"
+  apiVersion: v1
+  data:
+    ldap-sync.yml: |
+      kind: LDAPSyncConfig
+      apiVersion: v1
+      url: ${LDAP_URL}
+      insecure: true
+      bindDN: ${LDAP_BIND_DN}
+      bindPassword: ${LDAP_BIND_PASSWORD}
+      augmentedActiveDirectory:
+          groupsQuery:
+              baseDN: ${LDAP_GROUPS_SEARCH_BASE}
+              scope: sub
+              derefAliases: never
+              pageSize: 0
+          groupUIDAttribute: dn
+          groupNameAttributes: [ cn ]
+          groupMembershipAttributes: [ memberOf ]
+          usersQuery:
+              baseDN: ${LDAP_USERS_SEARCH_BASE}
+              scope: sub
+              derefAliases: never
+              filter: ${LDAP_GROUPS_FILTER}
+              pageSize: 0
+          userUIDAttribute: displayName
+          userNameAttributes: [ sAMAccountName ]
+          tolerateMemberNotFoundErrors: true
+          tolerateMemberOutOfScopeErrors: true
+- kind: "CronJob"
+  apiVersion: "batch/v2alpha1"
+  metadata:
+    name: "${JOB_NAME}"
+    labels:
+      template: "cronjob-ad-group-sync"
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: "Forbid"
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: "${JOB_NAME}"
+                image: "openshift3/jenkins-slave-base-rhel7"
+                command:
+                  - "/bin/bash"
+                  - "-c"
+                  - "oc adm groups sync --sync-config=/etc/config/ldap-group-sync.yaml --confirm"
+                volumeMounts:
+                  - mountPath: "/etc/config"
+                    name: "ldap-sync-volume"
+            volumes:
+              - configMap:
+                  items:
+                    - key: ldap-sync.yml
+                      path: ldap-group-sync.yaml
+                  name: ad-config
+                name: ldap-sync-volume
+            restartPolicy: "Never"
+            terminationGracePeriodSeconds: 30
+            activeDeadlineSeconds: 500
+            dnsPolicy: "ClusterFirst"
+            serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
+            serviceAccount: "${JOB_SERVICE_ACCOUNT}"
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    name: ad-group-syncer
+    labels:
+      template: "cronjob-ad-group-sync"
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - groups
+      verbs:
+        - get
+        - list
+        - create
+        - update
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:ad-group-syncers
+    labels:
+      template: "cronjob-ad-group-sync"
+  roleRef:
+    name: ad-group-syncer
+  subjects:
+  - kind: ServiceAccount
+    name: ${JOB_SERVICE_ACCOUNT}
+  userNames:
+  - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${JOB_SERVICE_ACCOUNT}
+    labels:
+      template: "cronjob-ad-group-sync"
+parameters:
+  - name: "NAMESPACE"
+    displayName: "Namespace"
+    description: "Name of the Namespace where to deploy the Scheduled Job"
+    value: "cluster-ops"
+    required: true
+  - name: "JOB_NAME"
+    displayName: "Job Name"
+    description: "Name of the Scheduled Job to Create."
+    value: "cronjob-ad-group-sync"
+    required: true
+  - name: "SCHEDULE"
+    displayName: "Cron Schedule"
+    description: "Cron Schedule to Execute the Job"
+    value: "@hourly"
+    required: true
+  - name: "JOB_SERVICE_ACCOUNT"
+    displayName: "Service Account Name"
+    description: "Name of the Service Account To Exeucte the Job As."
+    value: "ad-group-syncer"
+    required: true
+  - name: "KEEP_COMPLETE"
+    displayName: "Number of Completed Items"
+    description: "Number of completed items that will not be considered for pruning."
+    value: "5"
+    required: true
+  - name: "SUCCESS_JOBS_HISTORY_LIMIT"
+    displayName: "Successful Job History Limit"
+    description: "The number of successful jobs that will be retained"
+    value: "5"
+    required: true
+  - name: "FAILED_JOBS_HISTORY_LIMIT"
+    displayName: "Failed Job History Limit"
+    description: "The number of failed jobs that will be retained"
+    value: "5"
+    required: true
+  - name: "LDAP_URL"
+    displayName: "LDAP Server URL"
+    description: "URL of you LDAP server"
+    required: true
+  - name: "LDAP_BIND_DN"
+    displayName: "LDAP Bind User's DN"
+    description: "The Full DN for the user you wish to use to authenticate to LDAP"
+    required: true
+  - name: "LDAP_BIND_PASSWORD"
+    displayName: "LDAP Bind User's password"
+    description: "Password for the LDAP_BIND_DN user"
+    required: true
+  - name: "LDAP_GROUPS_SEARCH_BASE"
+    displayName: "Group search query"
+    description: "Location in LDAP tree where you will find groups"
+    required: true
+    value: "cn=groups,cn=accounts,dc=myorg,dc=example,dc=com"
+  - name: "LDAP_GROUPS_FILTER"
+    displayName: "Group Filter"
+    description: "LDAP Filter to use when deciding which groups to sync into OpenShift"
+    required: true
+    value: "(&(objectclass=ipausergroup)(memberOf=cn=openshift-users,cn=groups,cn=accounts,dc=myorg,dc=example,dc=com))"
+  - name: "LDAP_USERS_SEARCH_BASE"
+    displayName: "User search query"
+    description: "Location in LDAP tree where you will find users"
+    required: true
+    value: "cn=users,cn=accounts,dc=myorg,dc=example,dc=com"
+labels:
+  template: "cronjob-ad-group-sync"


### PR DESCRIPTION
Active Directory and LDAP function differently with Openshift.  Created a dedicated Active Directory Yaml.

#### What is this PR About?
This template can be used specifically for Active Directory, instead of heavily modifying the LDAP template and them executing on an OCP cluster.

#### How do we test this?
The instantiate template steps should suffice to test that the template is useful.  Just in case, below is the steps:

```
oc process -f jobs/cronjob-ldap-group-sync.yml \
  -p NAMESPACE="<project name from previous step>"
  -p LDAP_URL="ldap://idm-2.etl.rht-labs.com:389" \
  -p LDAP_BIND_DN="uid=ldap-user,cn=users,cn=accounts,dc=myorg,dc=example,dc=com" \
	-p LDAP_BIND_PASSWORD="password1" \
	-p LDAP_GROUPS_SEARCH_BASE="cn=groups,cn=accounts,dc=myorg,dc=example,dc=com" \
	-p LDAP_GROUPS_FILTER="(&(objectclass=ipausergroup)(memberOf=cn=ose_users,cn=groups,cn=accounts,dc=myorg,dc=example,dc=com))" \
	-p LDAP_USERS_SEARCH_BASE="cn=users,cn=accounts,dc=myorg,dc=example,dc=com" \
	| oc create -f- 
```

cc: @redhat-cop/day-in-the-life-ops
