### PR TITLE
Adding missing 'apiVersion' for some objects

### DIFF
--- a/jobs/cronjob-git-sync.yml
+++ b/jobs/cronjob-git-sync.yml
@@ -16,7 +16,7 @@ objects:
   data:
     ssh-privatekey: ${GIT_PRIVATE_KEY} 
 - kind: "CronJob"
-  apiVersion: "batch/v2alpha1"
+  apiVersion: "batch/v1beta1"
   metadata:
     name: "${JOB_NAME}"
     labels:

--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -87,7 +87,7 @@ objects:
       template: "cronjob-ldap-group-sync"
   rules:
     - apiGroups:
-        - ""
+        - user.openshift.io
       resources:
         - groups
       verbs:

--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -42,7 +42,7 @@ objects:
           tolerateMemberNotFoundErrors: true
           tolerateMemberOutOfScopeErrors: true
 - kind: "CronJob"
-  apiVersion: "batch/v2alpha1"
+  apiVersion: "batch/v1beta1"
   metadata:
     name: "${JOB_NAME}"
     labels:

--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -9,11 +9,11 @@ metadata:
     tags: "management,cronjob,ldap,group,sync"
 objects:
 - kind: ConfigMap
+  apiVersion: v1
   metadata:
     name: ldap-config
     labels:
       template: "cronjob-ldap-group-sync"
-  apiVersion: v1
   data:
     ldap-sync.yml: |
       kind: LDAPSyncConfig
@@ -79,8 +79,8 @@ objects:
             dnsPolicy: "ClusterFirst"
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
-- apiVersion: v1
-  kind: ClusterRole
+- kind: ClusterRole
+  apiVersion: v1
   metadata:
     name: ldap-group-syncer
     labels:
@@ -95,9 +95,9 @@ objects:
         - list
         - create
         - update
-- apiVersion: v1
+- kind: ClusterRoleBinding
+  apiVersion: v1
   groupNames: null
-  kind: ClusterRoleBinding
   metadata:
     name: system:ldap-group-syncers
     labels:
@@ -109,7 +109,8 @@ objects:
     name: ${JOB_SERVICE_ACCOUNT}
   userNames:
   - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
-- apiVersion: v1
+- kind: ServiceAccount
+  apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: ${JOB_SERVICE_ACCOUNT}

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -45,7 +45,7 @@ objects:
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
 - kind: ClusterRoleBinding
-  apiVersion: authorization.openshift.io/v1
+  apiVersion: v1
   metadata:
     name: system:build-pruners
     labels:

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -45,6 +45,7 @@ objects:
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
 - kind: ClusterRoleBinding
+  apiVersion: authorization.openshift.io/v1
   metadata:
     name: system:build-pruners
     labels:
@@ -57,6 +58,7 @@ objects:
   userNames:
   - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
 - kind: ServiceAccount
+  apiVersion: v1
   metadata:
     name: ${JOB_SERVICE_ACCOUNT}
     labels:

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -9,7 +9,7 @@ metadata:
     tags: management,cronjob,prune,builds,deployments
 objects:
 - kind: CronJob
-  apiVersion: batch/v2alpha1
+  apiVersion: batch/v1beta1
   metadata:
     name: "${JOB_NAME}-${PRUNE_TYPE}"
   spec:

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -41,6 +41,7 @@ objects:
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
 - kind: ClusterRoleBinding
+  apiVersion: authorization.openshift.io/v1
   metadata:
     name: system:image-pruners
     labels:
@@ -53,6 +54,7 @@ objects:
   userNames:
   - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
 - kind: ServiceAccount
+  apiVersion: v1
   metadata:
     name: ${JOB_SERVICE_ACCOUNT}
     labels:

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -9,7 +9,7 @@ metadata:
     tags: management,cronjob,prune,images
 objects:
 - kind: CronJob
-  apiVersion: batch/v2alpha1
+  apiVersion: batch/v1beta1
   metadata:
     name: "${JOB_NAME}"
   spec:

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -41,7 +41,7 @@ objects:
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
 - kind: ClusterRoleBinding
-  apiVersion: authorization.openshift.io/v1
+  apiVersion: v1
   metadata:
     name: system:image-pruners
     labels:

--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -4,16 +4,16 @@ kind: Template
 metadata:
   name: cronjob-prune-projects
 objects:
-- apiVersion: v1
-  kind: ImageStream
+- kind: ImageStream
+  apiVersion: v1
   metadata:
     annotations:
       description: Keeps track of changes in the application image
     name: ${NAME}
     labels:
       template: cronjob-prune-projects
-- apiVersion: v1
-  kind: BuildConfig
+- kind: BuildConfig
+  apiVersion: v1
   metadata:
     annotations:
       description: Defines how to build the application
@@ -39,8 +39,8 @@ objects:
       type: Docker
     triggers:
     - type: ConfigChange
-- apiVersion: batch/v2alpha1
-  kind: CronJob
+- kind: CronJob
+  apiVersion: batch/v2alpha1
   metadata:
     name: "${JOB_NAME}"
     labels:
@@ -74,8 +74,8 @@ objects:
             dnsPolicy: ClusterFirst
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
-- apiVersion: v1
-  kind: ClusterRoleBinding
+- kind: ClusterRoleBinding
+  apiVersion: authorization.openshift.io/v1
   metadata:
     name: system:project-pruners
     labels:
@@ -87,8 +87,8 @@ objects:
     name: ${JOB_SERVICE_ACCOUNT}
   userNames:
   - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
-- apiVersion: v1
-  kind: ServiceAccount
+- kind: ServiceAccount
+  apiVersion: v1
   metadata:
     name: ${JOB_SERVICE_ACCOUNT}
     labels:

--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -75,7 +75,7 @@ objects:
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
 - kind: ClusterRoleBinding
-  apiVersion: authorization.openshift.io/v1
+  apiVersion: v1
   metadata:
     name: system:project-pruners
     labels:

--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -40,7 +40,7 @@ objects:
     triggers:
     - type: ConfigChange
 - kind: CronJob
-  apiVersion: batch/v2alpha1
+  apiVersion: batch/v1beta1
   metadata:
     name: "${JOB_NAME}"
     labels:


### PR DESCRIPTION
#### What is this PR About?
Adding `apiVersion` for some objects as these are failing with OpenShift v3.9 otherwise. Also shifted some fields around to standardize a bit on how the `apiVersion` v.s. `kind` is listed (makes it easier to validate the content).

#### How do we test this?
Use the `openshift-applier` with an inventory referencing these files - apply the content to an OpenShift v3.9 cluster.

cc: @redhat-cop/casl 