### PR TITLE
Modify ldap sync job to prevent respawning

### DIFF
--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -62,7 +62,7 @@ objects:
                 command:
                   - "/bin/bash"
                   - "-c"
-                  - "oc adm groups sync --sync-config=/etc/config/ldap-group-sync.yaml --confirm"
+                  - "oc adm groups sync --sync-config=/etc/config/ldap-group-sync.yaml --confirm || :"
                 volumeMounts:
                   - mountPath: "/etc/config"
                     name: "ldap-sync-volume"


### PR DESCRIPTION
#### What is this PR About?
Modify the container command for `ldap-group-sync.yaml` to address the Job Controller limitation and avoid pods to be respawning all the time

#### How do we test this?
Follow instructions to deploy CronJobs as usual

cc: @redhat-cop/day-in-the-life-ops
