### PR TITLE
Update oc client to 3.9.x

### DIFF
--- a/images/prune-ocp-projects/Dockerfile
+++ b/images/prune-ocp-projects/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH=$PATH:/usr/local/bin
 
 ADD include/prune-ocp-projects.sh /usr/local/bin/
 
-RUN curl https://mirror.openshift.com/pub/openshift-v3/clients/3.7.18/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
+RUN curl https://mirror.openshift.com/pub/openshift-v3/clients/3.9.19/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
 RUN chmod +x /usr/local/bin/prune-ocp-projects.sh
 
 CMD [ "/usr/local/bin/prune-ocp-projects.sh" ]


### PR DESCRIPTION
#### What is this PR About?
Update `oc` client for `prune-ocp-projects` container to 3.9.x

#### How do we test this?
Follow deployment instructions as usual

cc: @redhat-cop/day-in-the-life-ops
