### PR TITLE
remove KEEP_COMPLETE that isn't referenced or used

### DIFF
--- a/jobs/cronjob-git-sync.yml
+++ b/jobs/cronjob-git-sync.yml
@@ -81,11 +81,6 @@ parameters:
     description: "Cron Schedule to Execute the Job"
     value: "@hourly"
     required: true
-  - name: "KEEP_COMPLETE"
-    displayName: "Number of Completed Items"
-    description: "Number of completed items that will not be considered for pruning."
-    value: "5"
-    required: true
   - name: "SUCCESS_JOBS_HISTORY_LIMIT"
     displayName: "Successful Job History Limit"
     description: "The number of successful jobs that will be retained"

--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -137,11 +137,6 @@ parameters:
     description: "Name of the Service Account To Exeucte the Job As."
     value: "ldap-group-syncer"
     required: true
-  - name: "KEEP_COMPLETE"
-    displayName: "Number of Completed Items"
-    description: "Number of completed items that will not be considered for pruning."
-    value: "5"
-    required: true
   - name: "SUCCESS_JOBS_HISTORY_LIMIT"
     displayName: "Successful Job History Limit"
     description: "The number of successful jobs that will be retained"


### PR DESCRIPTION
this isn't used anywhere, the closest things to it are
SUCCESS_JOBS_HISTORY_LIMIT and FAILED_JOBS_HISTORY_LIMIT

#### What is this PR About?

Removing an unused variable


#### How do we test this?

grep the file and observe `KEEP_COMPLETE` isn't used anywhere in it.

cc: @redhat-cop/day-in-the-life-ops
