### PR TITLE
Adding in alternative apiGroups

### DIFF
--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -87,6 +87,7 @@ objects:
       template: "cronjob-ldap-group-sync"
   rules:
     - apiGroups:
+        - ""
         - user.openshift.io
       resources:
         - groups


### PR DESCRIPTION
#### What is this PR About?
Through testing / use of `v3.9`, it seems that both empty ("") and "user.openshift.io" needs to be part of the apiGroups for a custom ClusterRole handling `groups`. Standard ClusterRoles also have both set, so I believe this change is compatible (and aligned) with the rest of the ClusterRoles. 

#### How do we test this?
Load up the cronjob and see that the ldap groups successfully syncs. 

cc: @redhat-cop/casl-ansible
