### PR TITLE
Remove duplicate kind declaration

### DIFF
--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -112,7 +112,6 @@ objects:
   - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
 - kind: ServiceAccount
   apiVersion: v1
-  kind: ServiceAccount
   metadata:
     name: ${JOB_SERVICE_ACCOUNT}
     labels:


### PR DESCRIPTION
#### What is this PR About?
There is a duplicate `kind` declaration when creating a service account in `cronjob-ldap-group-sync.yml`

#### How do we test this?
Deploy this template. Verify that service account is still created.

cc: @redhat-cop/day-in-the-life-ops
