### PR TITLE
Updating ldap group sync job template to have use image & tag params

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@ Describe the contents of the PR
 #### How do we test this?
 Provide commands/steps to test this PR.
 
-cc: @redhat-cop/day-in-the-life-ops
+cc: @redhat-cop/casl

--- a/jobs/cronjob-ldap-group-sync.yml
+++ b/jobs/cronjob-ldap-group-sync.yml
@@ -58,7 +58,7 @@ objects:
           spec:
             containers:
               - name: "${JOB_NAME}"
-                image: "openshift3/jenkins-slave-base-rhel7"
+                image: "${IMAGE}:${IMAGE_TAG}"
                 command:
                   - "/bin/bash"
                   - "-c"
@@ -174,5 +174,15 @@ parameters:
     description: "Location in LDAP tree where you will find users"
     required: true
     value: "cn=users,cn=accounts,dc=myorg,dc=example,dc=com"
+  - name: "IMAGE"
+    displayName: "Image"
+    description: "Image to use for the container."
+    required: true
+    value: "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+  - name: "IMAGE_TAG"
+    displayName: "Image Tag"
+    description: "Image Tag to use for the container."
+    required: true
+    value: "v3.11"
 labels:
   template: "cronjob-ldap-group-sync"


### PR DESCRIPTION
#### What is this PR About?
Was running into an issue with the templates hard-coded image it is using, so I have added params to allow setting specific images & tags.

#### How do we test this?
Process & run the template like usual & see that the default param values make sense and/or use custom values.

cc: @redhat-cop/day-in-the-life-ops
