### PR TITLE
add cassandra indexes truncate job

### DIFF
--- a/images/truncate-cassandra/Dockerfile
+++ b/images/truncate-cassandra/Dockerfile
@@ -1,6 +1,8 @@
-FROM centos:7
+FROM rhel7-minimal:latest
 
 MAINTAINER Ricardo Zanini <ricardozanini@gmail.com>
+
+ARG OC_CLIENT_DOWNLOAD_URL
 
 LABEL io.k8s.description="Truncate Cassandra tag index tables" \
       io.k8s.display-name="Truncate Cassandra Tables Job"
@@ -9,7 +11,7 @@ ENV PATH=$PATH:/usr/local/bin
 
 ADD include/truncate-cassandra-tag-metrics.sh /usr/local/bin/
 
-RUN curl https://mirror.openshift.com/pub/openshift-v3/clients/3.9.19/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
+RUN curl ${OC_CLIENT_DOWNLOAD_URL} | tar -C /usr/local/bin/ -xzf -
 RUN chmod +x /usr/local/bin/truncate-cassandra-tag-metrics.sh
 
 CMD [ "/usr/local/bin/truncate-cassandra-tag-metrics.sh" ]

--- a/images/truncate-cassandra/Dockerfile
+++ b/images/truncate-cassandra/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:7
+
+MAINTAINER Ricardo Zanini <ricardozanini@gmail.com>
+
+LABEL io.k8s.description="Truncate Cassandra tag index tables" \
+      io.k8s.display-name="Truncate Cassandra Tables Job"
+
+ENV PATH=$PATH:/usr/local/bin
+
+ADD include/truncate-cassandra-tag-metrics.sh /usr/local/bin/
+
+RUN curl https://mirror.openshift.com/pub/openshift-v3/clients/3.9.19/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
+RUN chmod +x /usr/local/bin/truncate-cassandra-tag-metrics.sh
+
+CMD [ "/usr/local/bin/truncate-cassandra-tag-metrics.sh" ]

--- a/images/truncate-cassandra/Dockerfile
+++ b/images/truncate-cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhel7-minimal:latest
+FROM rhel7:latest
 
 MAINTAINER Ricardo Zanini <ricardozanini@gmail.com>
 

--- a/images/truncate-cassandra/include/truncate-cassandra-tag-metrics.sh
+++ b/images/truncate-cassandra/include/truncate-cassandra-tag-metrics.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "$METRICS_NAMESPACE" ]]; then
+   echo "METRICS_NAMESPACE variable not defined"
+   exit 1;
+fi
+
+echo "Scalling down Heapster and Hawkular pods"
+oc -n ${METRICS_NAMESPACE} scale rc heapster --replicas=0
+oc -n ${METRICS_NAMESPACE} scale rc hawkular-metrics --replicas=0
+export CASSANDRA_POD=$(oc -n ${METRICS_NAMESPACE} get pods | grep ${CASSANDRA_CONTAINER_PREFIX} | head -n 1 | awk '{ print $1 }' )
+echo "Cassandra pod is ${CASSANDRA_POD}. Truncating tables"
+oc -n ${METRICS_NAMESPACE} exec ${CASSANDRA_POD} -- cqlsh --ssl -e "truncate table hawkular_metrics.metrics_tags_idx"
+oc -n ${METRICS_NAMESPACE} exec ${CASSANDRA_POD} -- cqlsh --ssl -e "truncate table hawkular_metrics.metrics_idx"
+echo "Scalling up Hawkular and Heapster pods"
+oc -n ${METRICS_NAMESPACE} scale rc hawkular-metrics --replicas=1
+oc -n ${METRICS_NAMESPACE} scale rc heapster --replicas=1
+

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -149,3 +149,22 @@ To instantiate the template, run the following.
 		-p VOL="Persistent Volume Claim name (can be ALL)" \
 		| oc create -f-
 	```
+
+### Truncate Cassandra Indexes
+
+Job to clean the `metrics_tags_idx` table from time to time to avoid metrics slowlyness. For more detailed info, please refer to [Bugzilla 1569096](https://bugzilla.redhat.com/show_bug.cgi?id=1569096).
+
+This job is pretty similar to the prune ones:
+
+1. Create a project in which to host your job.
+	```
+	oc new-project <project>
+	```
+
+2. Instantiate the template
+```
+oc process -f <template_file> \
+-p NAMESPACE="<project name from previous step>" -p METRICS_NAMESPACE="<project name where metrics are deployed*>"  | oc create -f-
+```
+
+**The project where metrics are deployed normally is openshift-infra*.

--- a/jobs/cronjob-truncate-cassandra-tag-metrics.yml
+++ b/jobs/cronjob-truncate-cassandra-tag-metrics.yml
@@ -8,6 +8,47 @@ metadata:
     iconClass: icon-shadowman
     tags: management,cronjob,truncate,cassandra
 objects:
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: ${JOB_SERVICE_ACCOUNT}
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+- kind: ClusterRole
+  apiVersion: v1
+  metadata:
+    name: cassandra-cleaner
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:  
+    - pods
+    - pods/exec
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    verbs:
+    - get
+    - list
+    - create
+    - update
+- apiVersion: authorization.openshift.io/v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    name: cassandra-cleaners
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+  roleRef:
+    name: cassandra-cleaner
+    namespace: ${NAMESPACE}
+  subjects:
+  - kind: SystemUser
+    name: system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
+  userNames:
+  - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -83,46 +124,6 @@ objects:
             dnsPolicy: ClusterFirst
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
-- kind: ClusterRole
-  apiVersion: v1
-  metadata:
-    name: cassandra-cleaner
-    labels:
-      template: "cronjob-truncate-cassandra-tag-metrics"
-  rules:
-    - apiGroups:
-        - ""
-        - user.openshift.io
-      resources:
-        - deploymentconfigs.apps.openshift.io/scale
-        - pods/exec
-        - replicationcontrollers/scale
-        - replicationcontrollers.extensions/scale
-      verbs:
-        - get
-        - list
-        - create
-        - update
-- kind: ClusterRoleBinding
-  apiVersion: v1
-  groupNames: null
-  metadata:
-    name: cassandra-cleaners
-    labels:
-      template: "cronjob-truncate-cassandra-tag-metrics"
-  roleRef:
-    name: cassandra-cleaner
-  subjects:
-  - kind: ServiceAccount
-    name: ${JOB_SERVICE_ACCOUNT}
-  userNames:
-  - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
-- kind: ServiceAccount
-  apiVersion: v1
-  metadata:
-    name: ${JOB_SERVICE_ACCOUNT}
-    labels:
-      template: "cronjob-truncate-cassandra-tag-metrics"
 parameters:
 - description: The name assigned to all of the frontend objects defined in this template.
   displayName: Name
@@ -182,7 +183,7 @@ parameters:
 - description: Base image for the builds
   name: BASE_IMAGE
   required: true
-  value: "rhel7-minimal"
+  value: "rhel7"
 - description: The tag for the iamge
   displayName: Image Tag
   name: TAG

--- a/jobs/cronjob-truncate-cassandra-tag-metrics.yml
+++ b/jobs/cronjob-truncate-cassandra-tag-metrics.yml
@@ -1,0 +1,168 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: cronjob-truncate-cassandra-tag-metrics
+  annotations:
+    description: Scheduled Task to Truncate Cassandra Tags Index
+    iconClass: icon-shadowman
+    tags: management,cronjob,truncate,cassandra
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    annotations:
+      description: Keeps track of changes in the application image
+    name: ${NAME}
+    labels:
+      template: cronjob-truncate-cassandra-tag-metrics
+  spec:
+    lookupPolicy:
+      local: true
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    annotations:
+      description: Defines how to build the application
+    name: ${NAME}
+    labels:
+      template: cronjob-truncate-cassandra-tag-metrics
+  spec:
+    completionDeadlineSeconds: "1800"
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:${TAG}
+    runPolicy: Serial
+    source:
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${SOURCE_REPOSITORY_REF}"
+      contextDir: "${CONTEXT_DIR}"
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: "${BASE_IMAGE}"
+      type: Docker
+    triggers:
+    - type: ConfigChange
+- kind: CronJob
+  apiVersion: batch/v1beta1
+  metadata:
+    name: "${JOB_NAME}"
+    labels:
+      template: cronjob-truncate-cassandra-tag-metrics
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: "${JOB_NAME}"
+              image: "${NAME}:${TAG}"
+              command: 
+              - "/bin/bash"
+              - "-c"
+              - "/usr/local/bin/truncate-cassandra-tag-metrics.sh"
+              env:
+              - name: METRICS_NAMESPACE
+                value: "${METRICS_NAMESPACE}"
+              - name: CASSANDRA_CONTAINER_PREFIX
+                value: "${CASSANDRA_CONTAINER_PREFIX}"
+            restartPolicy: Never
+            terminationGracePeriodSeconds: 30
+            activeDeadlineSeconds: 500
+            dnsPolicy: ClusterFirst
+            serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
+            serviceAccount: "${JOB_SERVICE_ACCOUNT}"
+- kind: ClusterRoleBinding
+  apiVersion: v1
+  metadata:
+    name: system:cassandra-cleaner
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+  roleRef:
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    name: ${JOB_SERVICE_ACCOUNT}
+  userNames:
+  - system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: ${JOB_SERVICE_ACCOUNT}
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+parameters:
+- description: The name assigned to all of the frontend objects defined in this template.
+  displayName: Name
+  name: NAME
+  required: true
+  value: truncate-cassandra-tag-metrics
+- name: JOB_NAME
+  displayName: Job Name
+  description: Name of the Scheduled Job to Create.
+  value: cronjob-truncate-cassandra-tag-metrics
+  required: true
+- name: SCHEDULE
+  displayName: Cron Schedule
+  description: Cron Schedule to Execute the Job
+  value: 0 0 * * *
+  required: true
+- name: JOB_SERVICE_ACCOUNT
+  displayName: Service Account Name
+  description: Name of the Service Account To Exeucte the Job As.
+  value: pruner
+  required: true
+- name: SUCCESS_JOBS_HISTORY_LIMIT
+  displayName: Successful Job History Limit
+  description: The number of successful jobs that will be retained
+  value: '5'
+  required: true
+- name: FAILED_JOBS_HISTORY_LIMIT
+  displayName: Failed Job History Limit
+  description: The number of failed jobs that will be retained
+  value: '5'
+  required: true
+- name: "NAMESPACE"
+  displayName: "Namespace where this is deployed"
+  description: "Namespace where this is deployed."
+  value: "cluster-ops"
+  required: true
+- name: "METRICS_NAMESPACE"
+  displayName: "Namespace where metrics is deployed"
+  description: "Namespace where metrics is deployed."
+  value: "openshift-infra"
+  required: true
+- name: "CASSANDRA_CONTAINER_PREFIX"
+  displayName: "Prefix of the cassandra pod"
+  description: "Prefix of the cassandra pod."
+  value: "hawkular-cassandra"
+  required: true
+- description: Git branch/tag reference
+  name: SOURCE_REPOSITORY_REF
+  value: master
+- description: Git source URL for application
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/redhat-cop/openshift-management
+- description: Path within Git repository to build; empty for root of repository
+  name: CONTEXT_DIR
+  value: "images/truncate-cassandra"
+- description: Base image for the buils
+  name: BASE_IMAGE
+  required: true
+  value: "centos:7"
+- description: The tag for the iamge
+  displayName: Image Tag
+  name: TAG
+  required: true
+  value: latest
+labels:
+  template: cronjob-truncate-cassandra-tag-metrics

--- a/jobs/cronjob-truncate-cassandra-tag-metrics.yml
+++ b/jobs/cronjob-truncate-cassandra-tag-metrics.yml
@@ -43,7 +43,6 @@ objects:
       template: "cronjob-truncate-cassandra-tag-metrics"
   roleRef:
     name: cassandra-cleaner
-    namespace: ${NAMESPACE}
   subjects:
   - kind: SystemUser
     name: system:serviceaccount:${NAMESPACE}:${JOB_SERVICE_ACCOUNT}

--- a/jobs/cronjob-truncate-cassandra-tag-metrics.yml
+++ b/jobs/cronjob-truncate-cassandra-tag-metrics.yml
@@ -32,7 +32,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ${NAME}:${TAG}
+        name: ${NAME}:latest
     runPolicy: Serial
     source:
       git:
@@ -43,7 +43,10 @@ objects:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: "${BASE_IMAGE}"
+          name: "${BASE_IMAGE}:${TAG}"
+        buildArgs:
+          - name: OC_CLIENT_DOWNLOAD_URL
+            value: ${OC_CLIENT_DOWNLOAD_URL}
       type: Docker
     triggers:
     - type: ConfigChange
@@ -64,7 +67,7 @@ objects:
           spec:
             containers:
             - name: "${JOB_NAME}"
-              image: "${NAME}:${TAG}"
+              image: "${NAME}:latest"
               command: 
               - "/bin/bash"
               - "-c"
@@ -80,14 +83,35 @@ objects:
             dnsPolicy: ClusterFirst
             serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
             serviceAccount: "${JOB_SERVICE_ACCOUNT}"
-- kind: ClusterRoleBinding
+- kind: ClusterRole
   apiVersion: v1
   metadata:
-    name: system:cassandra-cleaner
+    name: cassandra-cleaner
+    labels:
+      template: "cronjob-truncate-cassandra-tag-metrics"
+  rules:
+    - apiGroups:
+        - ""
+        - user.openshift.io
+      resources:
+        - deploymentconfigs.apps.openshift.io/scale
+        - pods/exec
+        - replicationcontrollers/scale
+        - replicationcontrollers.extensions/scale
+      verbs:
+        - get
+        - list
+        - create
+        - update
+- kind: ClusterRoleBinding
+  apiVersion: v1
+  groupNames: null
+  metadata:
+    name: cassandra-cleaners
     labels:
       template: "cronjob-truncate-cassandra-tag-metrics"
   roleRef:
-    name: cluster-admin
+    name: cassandra-cleaner
   subjects:
   - kind: ServiceAccount
     name: ${JOB_SERVICE_ACCOUNT}
@@ -155,14 +179,19 @@ parameters:
 - description: Path within Git repository to build; empty for root of repository
   name: CONTEXT_DIR
   value: "images/truncate-cassandra"
-- description: Base image for the buils
+- description: Base image for the builds
   name: BASE_IMAGE
   required: true
-  value: "centos:7"
+  value: "rhel7-minimal"
 - description: The tag for the iamge
   displayName: Image Tag
   name: TAG
   required: true
   value: latest
+- name: OC_CLIENT_DOWNLOAD_URL
+  displayName: oc client download URL
+  description: oc client binary download URL
+  value: https://mirror.openshift.com/pub/openshift-v3/clients/3.9.19/linux/oc.tar.gz
+  required: true
 labels:
   template: cronjob-truncate-cassandra-tag-metrics


### PR DESCRIPTION
#### What is this PR About?
This job truncates the tag metrics table to avoid overwhelming cassandra with old metrics. More details here: https://bugzilla.redhat.com/show_bug.cgi?id=1569096

#### How do we test this?
Just follow the instructions on the README, section **Truncate Cassandra Indexes**. Must have a cluster with metrics installed.

cc: @redhat-cop/casl
