### PR TITLE
Fixing int32/int64 issues on re-apply

### DIFF
--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -24,7 +24,7 @@ objects:
     labels:
       template: cronjob-prune-projects
   spec:
-    completionDeadlineSeconds: "1800"
+    completionDeadlineSeconds: 1800
     output:
       to:
         kind: ImageStreamTag
@@ -52,8 +52,8 @@ objects:
   spec:
     schedule: "${SCHEDULE}"
     concurrencyPolicy: Forbid
-    successfulJobsHistoryLimit: "${SUCCESS_JOBS_HISTORY_LIMIT}"
-    failedJobsHistoryLimit: "${FAILED_JOBS_HISTORY_LIMIT}"
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
     jobTemplate:
       spec:
         template:


### PR DESCRIPTION
#### What is this PR About?
Fixing issues related to int32/int64 v.s. string for re-apply 

#### How do we test this?
Use `oc process` and `oc apply` to apply this template to a cluster. Then run it a second time and see that it's successfully re-applied. 

cc: @redhat-cop/casl
