### PR TITLE
Use UBI for project prune image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repo contains a set of general _good practice_ jobs that can be used as a starting point for operationalizing an OpenShift Container Platform cluster. This repo breaks down into several categories:
 
 - *jobs* - a set of _jobs_ (including _CronJob_) templates for common tasks
+
+- *images* - utility images for common tasks

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,7 @@
+# Images
+
+This directory contains a collection of utility images for Openshift tasks.
+
+### Prune Openshift projects
+
+The [prune-ocp-projects](prune-ocp-projects) declaratively prunes projects based on creation date. Projects can beexcluded from being pruned by annotating the project or by excluding it based on name.

--- a/images/prune-ocp-projects/Dockerfile
+++ b/images/prune-ocp-projects/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi
 
 LABEL io.k8s.description="OCP Project Pruner" \
       io.k8s.display-name="OCP Project Pruner"
@@ -7,7 +7,7 @@ ENV PATH=$PATH:/usr/local/bin
 
 ADD include/prune-ocp-projects.sh /usr/local/bin/
 
-RUN curl https://mirror.openshift.com/pub/openshift-v3/clients/3.9.19/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf -
-RUN chmod +x /usr/local/bin/prune-ocp-projects.sh
+RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf - && \
+    chmod +x /usr/local/bin/prune-ocp-projects.sh
 
 CMD [ "/usr/local/bin/prune-ocp-projects.sh" ]

--- a/images/prune-ocp-projects/Dockerfile
+++ b/images/prune-ocp-projects/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH=$PATH:/usr/local/bin
 
 ADD include/prune-ocp-projects.sh /usr/local/bin/
 
-RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf - && \
+RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz | tar -C /usr/local/bin/ -xzf - && \
     chmod +x /usr/local/bin/prune-ocp-projects.sh
 
 CMD [ "/usr/local/bin/prune-ocp-projects.sh" ]

--- a/images/prune-ocp-projects/README.md
+++ b/images/prune-ocp-projects/README.md
@@ -1,0 +1,22 @@
+# Prune OCP projects
+
+Use this image to prune Openshift projects
+
+- Based on UBI 8
+- Uses oc client 4.4
+
+## Build image
+
+### Dockerfile
+```
+docker build -t prune-ocp-projects .
+```
+
+### Buildah
+```
+./buildah.sh
+```
+or
+```
+buildah build -t prune-ocp-projects .
+```

--- a/images/prune-ocp-projects/buildah.sh
+++ b/images/prune-ocp-projects/buildah.sh
@@ -6,7 +6,7 @@ set -o errexit
 container=$(buildah from registry.access.redhat.com/ubi8/ubi)
 buildah config --label io.k8s.description="OCP Project Pruner" --label io.k8s.display-name="OCP Project Pruner" --env PATH='$PATH:/usr/local/bin' $container
 buildah add $container include/prune-ocp-projects.sh /usr/local/bin/
-buildah run $container -- curl -Lo /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz
+buildah run $container -- curl -Lo /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz
 buildah run $container -- tar -C /usr/local/bin/ -xzf /tmp/oc.tar.gz
 buildah run $container -- rm /tmp/oc.tar.gz
 buildah config --cmd /usr/local/bin/prune-ocp-projects.sh $container

--- a/images/prune-ocp-projects/buildah.sh
+++ b/images/prune-ocp-projects/buildah.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+# Create the container
+container=$(buildah from registry.access.redhat.com/ubi8/ubi)
+buildah config --label io.k8s.description="OCP Project Pruner" --label io.k8s.display-name="OCP Project Pruner" --env PATH='$PATH:/usr/local/bin' $container
+buildah add $container include/prune-ocp-projects.sh /usr/local/bin/
+buildah run $container -- curl -Lo /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz
+buildah run $container -- tar -C /usr/local/bin/ -xzf /tmp/oc.tar.gz
+buildah run $container -- rm /tmp/oc.tar.gz
+buildah config --cmd /usr/local/bin/prune-ocp-projects.sh $container
+
+buildah commit $container prune-ocp-projects:latest


### PR DESCRIPTION
#### What is this PR About?
- Use UBI 8 as base image for prune image
- Update oc client to v4.2
- Add script for buildah

#### How do we test this?
```
docker build -t prune-ocp-projects images/prune-ocp-projects
```
or
```
images/prune-ocp-projects/buildah.sh
```

cc: @redhat-cop/casl
