### PR TITLE
Gitlab cleanup job

### DIFF
--- a/.github/workflows/gitlab-del-projects-container-build.yaml
+++ b/.github/workflows/gitlab-del-projects-container-build.yaml
@@ -1,0 +1,29 @@
+name: Gitlab Delete Projects Container
+
+on:
+  push:
+    branches:
+      - gitlab-cleanup
+    paths:
+      - jobs/gitlab-delete-stale-projects/**
+      - .github/workflows/gitlab-del-projects-container-build.yaml
+
+jobs:
+  build-gitlab-delete-project:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: echo var
+      run: |
+        echo version name is: ${{ github.event.repository.name }}
+        echo repository is: ${{ github.repository }}
+    - name: Login quay.io
+      run: echo ${{ secrets.QUAY_PASSWORD }} | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
+    - name: Build Container
+      run: docker build jobs/gitlab-delete-stale-projects -t quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+    - name: Push Container 
+      run: docker push quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+    - name: Tag Latest
+      run: docker tag quay.io/mcanoy/gitlab-cleanup:${{ github.sha }} quay.io/mcanoy/gitlab-cleanup:master
+    - name: Push branch tag
+      run: docker push quay.io/mcanoy/gitlab-cleanup:master

--- a/.github/workflows/gitlab-del-projects-container-build.yaml
+++ b/.github/workflows/gitlab-del-projects-container-build.yaml
@@ -3,7 +3,7 @@ name: Gitlab Delete Projects Container
 on:
   push:
     branches:
-      - gitlab-cleanup
+      - master
     paths:
       - jobs/gitlab-delete-stale-projects/**
       - .github/workflows/gitlab-del-projects-container-build.yaml
@@ -20,10 +20,10 @@ jobs:
     - name: Login quay.io
       run: echo ${{ secrets.QUAY_PASSWORD }} | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
     - name: Build Container
-      run: docker build jobs/gitlab-delete-stale-projects -t quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+      run: docker build jobs/gitlab-delete-stale-projects -t quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
     - name: Push Container 
-      run: docker push quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+      run: docker push quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
     - name: Tag Latest
-      run: docker tag quay.io/mcanoy/gitlab-cleanup:${{ github.sha }} quay.io/mcanoy/gitlab-cleanup:master
+      run: docker tag quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }} quay.io/redhat-cop/gitlab-cleanup:master
     - name: Push branch tag
-      run: docker push quay.io/mcanoy/gitlab-cleanup:master
+      run: docker push quay.io/redhat-cop/gitlab-cleanup:master

--- a/.github/workflows/gitlab-del-projects-release.yaml
+++ b/.github/workflows/gitlab-del-projects-release.yaml
@@ -1,0 +1,28 @@
+name: Gitlab Delete Projects Release Tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: tag with release version
+      uses: tinact/docker.image-retag@1.0.2
+      with:
+        image_name: mcanoy/gitlab-cleanup
+        image_old_tag: ${{ github.sha }}
+        image_new_tag: ${{ github.event.release.tag_name }}
+        registry: quay.io
+        registry_username: ${{ secrets.QUAY_USERNAME }}
+        registry_password: ${{ secrets.QUAY_PASSWORD }}
+    - name: tag with latest
+      uses: tinact/docker.image-retag@1.0.2
+      with:
+        image_name: mcanoy/gitlab-cleanup
+        image_old_tag: ${{ github.sha }}
+        registry: quay.io
+        registry_username: ${{ secrets.QUAY_USERNAME }}
+        registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/gitlab-del-projects-release.yaml
+++ b/.github/workflows/gitlab-del-projects-release.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: tag with release version
       uses: tinact/docker.image-retag@1.0.2
       with:
-        image_name: mcanoy/gitlab-cleanup
+        image_name: redhat-cop/gitlab-cleanup
         image_old_tag: ${{ github.sha }}
         image_new_tag: ${{ github.event.release.tag_name }}
         registry: quay.io
@@ -21,7 +21,7 @@ jobs:
     - name: tag with latest
       uses: tinact/docker.image-retag@1.0.2
       with:
-        image_name: mcanoy/gitlab-cleanup
+        image_name: redhat-cop/gitlab-cleanup
         image_old_tag: ${{ github.sha }}
         registry: quay.io
         registry_username: ${{ secrets.QUAY_USERNAME }}

--- a/jobs/gitlab-delete-stale-projects/Chart.yaml
+++ b/jobs/gitlab-delete-stale-projects/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+name: gitlab-cleanup
+description: A Helm chart to clean up stale gitlab groups and projects
+
+type: application
+
+version: v0.1.0
+appVersion: v0.1.0

--- a/jobs/gitlab-delete-stale-projects/Chart.yaml
+++ b/jobs/gitlab-delete-stale-projects/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: gitlab-cleanup
 description: A Helm chart to clean up stale gitlab groups and projects
 

--- a/jobs/gitlab-delete-stale-projects/Dockerfile
+++ b/jobs/gitlab-delete-stale-projects/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+LABEL maintainer="Red Hat Services"
+
+# Update image
+RUN dnf update -y && rm -rf /var/cache/yum
+
+RUN dnf install -y python3; yum clean all
+
+RUN python3 -m pip install requests
+
+ENV LOG_LEVEL=INFO
+ENV DRY_RUN=TRUE
+
+USER root
+RUN yum install -y python3-pip
+USER 1001
+
+ADD gitlab-cleanup.py .
+
+CMD ["python3", "gitlab-cleanup.py"]

--- a/jobs/gitlab-delete-stale-projects/README.md
+++ b/jobs/gitlab-delete-stale-projects/README.md
@@ -47,7 +47,7 @@ The following variables maybe configured.
 | `cron.schedule`  | cronjob | The cron schedule | `"1 0 * * *"` |
 | `cron.historyLimit`  | cronjob | The amount of job runs to retain. | `5` |
 | `generateSecret`  | secret | If true, then helm will generate the secret with values set at `env.secret.xxx`. | `false` |
-| `env.deleteAfterInHours`  | cronjob | The job will delete itetms that are older than this amount of time. | `100 years` |
+| `env.deleteAfterInHours`  | cronjob | The job will delete itetms that are older than this amount of time. | `1 year` |
 | `env.dryRun`  | cronjob | If true, then this job will not perform the deletes. Good for tetsting. | `true` |
 | `env.logLevel`  | cronjob | Set the application log level. | `INFO` |
 | `env.secret.name`  | cronjob, secret | A reference to an opaque secret that is deployed in the same namespace. Can be generated if necessary. | `secret-gitlab-info` |

--- a/jobs/gitlab-delete-stale-projects/README.md
+++ b/jobs/gitlab-delete-stale-projects/README.md
@@ -47,7 +47,7 @@ The following variables maybe configured.
 | `cron.schedule`  | cronjob | The cron schedule | `"1 0 * * *"` |
 | `cron.historyLimit`  | cronjob | The amount of job runs to retain. | `5` |
 | `generateSecret`  | secret | If true, then helm will generate the secret with values set at `env.secret.xxx`. | `false` |
-| `env.deleteAfterInHours`  | cronjob | The job will delete itetms that are older than this amount of time. | `1 year` |
+| `env.deleteAfterInHours`  | cronjob | The job will delete itetms that are older than this amount of time. | `100 years` |
 | `env.dryRun`  | cronjob | If true, then this job will not perform the deletes. Good for tetsting. | `true` |
 | `env.logLevel`  | cronjob | Set the application log level. | `INFO` |
 | `env.secret.name`  | cronjob, secret | A reference to an opaque secret that is deployed in the same namespace. Can be generated if necessary. | `secret-gitlab-info` |

--- a/jobs/gitlab-delete-stale-projects/README.md
+++ b/jobs/gitlab-delete-stale-projects/README.md
@@ -4,6 +4,11 @@
 
 A cronjob that enables OpenShift to delete Gitlab projects that have become stale by checking the age of a repo. This also deletes groups that have no projects. Provide the job a top level group and it will search all projects under it and delete stale ones based on last activity and also remove empty groups.
 
+The cronjob will not delete in the follow cases:
+
+1. A group with the text `DO_NOT_DELETE` in the description will not delete the group, any subgroup and projects in the group and subgroups.
+2.  A project wit the text `DO_NOT_DELETE` in the description or a tag `DO_NOT_DELETE` in the tag list.
+
 **Caution:** this jobs performs hard deletes. The actual deletion policy is influenced by overarching settings in Gitlab.
 
 ## Using This Chart

--- a/jobs/gitlab-delete-stale-projects/README.md
+++ b/jobs/gitlab-delete-stale-projects/README.md
@@ -1,0 +1,67 @@
+![Gitlab Delete Projects Container](https://github.com/redhat-cop/openshift-management/workflows/Gitlab%20Delete%20Projects%20Container/badge.svg)
+
+# Gitlab Delete Projects Job
+
+A cronjob that enables OpenShift to delete Gitlab projects that have become stale by checking the age of a repo. This also deletes groups that have no projects. Provide the job a top level group and it will search all projects under it and delete stale ones based on last activity and also remove empty groups.
+
+**Caution:** this jobs performs hard deletes. The actual deletion policy is influenced by overarching settings in Gitlab.
+
+## Using This Chart
+
+This chart is geared toward Helm 3.
+
+1. Clone the target repo
+
+```
+git clone https://github.com/redhat-cop/openshift-management.git
+```
+
+2. Change into ths job's directory
+
+```
+cd openshift-management/charts/gitlab-delete-stale-projects
+```
+
+3. Deploy using the follow Helm command:
+
+```
+helm template . \
+  --set env.secret.name=my-openshift-secret-ref \
+  --set env.secret.gitlabApiUrl=https//my.gitlab.base.com \
+  --set env.secret.personalAccessToken=bot-token-value \
+  --set env.secret.parentRepoId=-1 \
+| oc apply -f - -n target-namespace
+```
+
+The following variables maybe configured.
+
+| Variable  | Used by | Usage | Default |
+|---|---|--|--|
+| `image.name`  | cronjob | The name of the image | `quay.io/redhat-cop/gitlab-cleanup` |
+| `image.tag`  | cronjob | The tag of the image | `latest` |
+| `cron.schedule`  | cronjob | The cron schedule | `"1 0 * * *"` |
+| `cron.historyLimit`  | cronjob | The amount of job runs to retain. | `5` |
+| `generateSecret`  | secret | If true, then helm will generate the secret with values set at `env.secret.xxx`. | `false` |
+| `env.deleteAfterInHours`  | cronjob | The job will delete itetms that are older than this amount of time. | `100 years` |
+| `env.dryRun`  | cronjob | If true, then this job will not perform the deletes. Good for tetsting. | `true` |
+| `env.logLevel`  | cronjob | Set the application log level. | `INFO` |
+| `env.secret.name`  | cronjob, secret | A reference to an opaque secret that is deployed in the same namespace. Can be generated if necessary. | `secret-gitlab-info` |
+| `env.gitlabApiUrl`  | cronjob | The url of the gitlab instance |
+| `env.secret.personalAccessToken`  | secret | The personal access token for the user accessing gitlab. Bot recommended |
+| `env.parentGroupId`  | cronjob | A reference to an opaque secret. Can be generated if necessary. |
+
+## Development
+
+The container can be built and run locally
+
+To build:
+
+```
+docker build . -t gitlab-clean
+```
+
+To run:
+
+```
+docker run -e DRY_RUN=true -e PARENT_GROUP_ID=-10 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com -e DELETE_AFTER_HOURS=240000 -e LOG_LEVEL=DEBUG gitlab-cleans
+```

--- a/jobs/gitlab-delete-stale-projects/README.md
+++ b/jobs/gitlab-delete-stale-projects/README.md
@@ -68,5 +68,5 @@ docker build . -t gitlab-clean
 To run:
 
 ```
-docker run -e DRY_RUN=true -e PARENT_GROUP_ID=-10 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com -e DELETE_AFTER_HOURS=240000 -e LOG_LEVEL=DEBUG gitlab-cleans
+docker run -e DRY_RUN=true -e PARENT_GROUP_ID=-10 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com -e DELETE_AFTER_HOURS=240000 -e LOG_LEVEL=DEBUG gitlab-clean
 ```

--- a/jobs/gitlab-delete-stale-projects/gitlab-cleanup.py
+++ b/jobs/gitlab-delete-stale-projects/gitlab-cleanup.py
@@ -1,0 +1,169 @@
+import os
+import json
+import requests
+import datetime
+import logging
+import math
+
+currentTime = datetime.datetime.now()
+
+logging.basicConfig(level="INFO")
+logger = logging.getLogger("com.redhat.labs")
+logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
+
+gitlab_api_url = '/api/v4'
+git_base_url = os.environ.get('GITLAB_API_URL')
+git_token = os.environ.get('GIT_TOKEN')
+parent_group_id = os.environ.get('PARENT_GROUP_ID')
+delete_after_hours_string = os.environ.get('DELETE_AFTER_HOURS')
+delete_after_hours = 2147483647 # default but line above must be set and is enforced
+dry_run = os.environ.get('DRY_RUN').lower() == 'true'
+
+def check_env_vars():
+    if parent_group_id is None:
+        raise ValueError('OMP Parent Group (PARENT_GROUP_ID) is required')
+    if not parent_group_id.isnumeric():
+        raise ValueError('OMP Parent Group (PARENT_GROUP_ID) has an invalid value of ' + parent_group)
+    if not git_token:
+        raise ValueError('Git Token (GIT_TOKEN) is required')
+    if not git_base_url:
+        raise ValueError('Git Url base url (GITLAB_API_URL) is required (eg. https://gitlab.com)')
+    if not delete_after_hours_string:
+        raise ValueError('You must set a time period to delete projects (DELETE_AFTER_HOURS)')
+    if not delete_after_hours_string.isnumeric():
+        raise ValueError('You must set a time period to delete projects (DELETE_AFTER_HOURS)')
+
+# clean groups and projects at our below this level of the group hierarchy
+# uses a staleness time measure to decide whether to delete
+# if a group has no projects or subgroups it should also be deleted
+# careful - recursion in use
+def clean_group(group_id, group_name):
+    cleanGroupDeleted = False
+
+    logger.debug(f'clean group {group_id} - {group_name}')
+
+    subgroups = find_subgroups(group_id)
+    subgroup_count = len(subgroups)
+
+    for subgroup in subgroups:
+        deleted = clean_group(subgroup['id'], subgroup['name'])
+        logger.debug(f"subgroup {subgroup['name']}")
+        if deleted:
+            subgroup_count -= 1
+
+    projects = find_projects(group_id)
+    all_projects_deleted = True
+    for project in projects:
+        if is_project_stale(project):
+            delete_project(project)
+        else:
+            all_projects_deleted = False
+
+    if subgroup_count == 0 and all_projects_deleted:
+        cleanGroupDeleted = delete_group(group_id, group_name)
+
+    logger.debug(f'clean group {group_id} finished')
+    return cleanGroupDeleted
+
+# end clean_group
+
+# returns a list of subgroups for the super group_id
+def find_subgroups(group_id):
+    logger.debug(f'find subgroups {group_id}')
+
+    response = requests.get(
+        f'{git_base_url}{gitlab_api_url}/groups/{group_id}/subgroups',
+        headers={"PRIVATE-TOKEN": git_token, 'Content-Type': 'application/json'},
+    )
+
+    if response.status_code == 200:
+        return json.loads(response.text);
+    if response.status_code == 401:
+        raise ValueError('Git Token is not valid')
+
+    return []
+# end find_groups
+
+def find_projects(group_id):
+    logger.debug(f'find projects {group_id}')
+
+    response = requests.get(
+        f'{git_base_url}{gitlab_api_url}/groups/{group_id}/projects',
+        headers={"PRIVATE-TOKEN": git_token, 'Content-Type': 'application/json'},
+    )
+    projects = json.loads(response.text)
+
+    logger.debug(f'project count = {len(projects)}')
+    return projects
+# end find_projects
+
+def delete_group(group_id, group_name):
+    if(group_name == 'PARENT'):
+        return False;
+
+def delete_group(group_id, group_name):
+    logger.info(f'delete group {group_id} {group_name} dry-run {dry_run}')
+
+    if not dry_run:
+        response = requests.delete(
+            f'{git_base_url}{gitlab_api_url}/groups/{group_id}',
+            headers={"PRIVATE-TOKEN": git_token},
+        )
+
+        if response.status_code == 202:
+            logger.warn(f"deleted group {group_id}")
+            return True
+
+        logger.error(f"Failed to delete group {group_id} code {response.status}")
+
+    return False
+# end delete_group
+
+def delete_project(project):
+    project_id = project['id']
+    logger.info(f"delete project {project_id} { project['name']} dry-run {dry_run}")
+
+    if not dry_run:
+        response = requests.delete(
+            f"{git_base_url}{gitlab_api_url}/projects/{project_id}",
+            headers={"PRIVATE-TOKEN": git_token},
+        )
+
+        if response.status_code == 202:
+            logger.warn(f"deleted project {project_id} { project['name']} ")
+            return True
+
+        logger.error(f"Failed to delete project {project_id} { project['name']}  code {response.status}")
+
+    return False
+#end delete_project
+
+# a job is considered stale if the amount of time that has occurred since its last activity is greater than the threshold amount of hours set in the env
+def is_project_stale(project):
+    shouldDelete = False
+
+    logger.debug(f"is_project stale {project['path_with_namespace']}")
+
+    lastActivity = datetime.datetime.strptime(project['last_activity_at'], '%Y-%m-%dT%H:%M:%S.%fZ')
+    passedTime = currentTime - lastActivity
+    elapsed_hours = passedTime.total_seconds() / 3600
+    logger.debug(f"Last Activity {lastActivity:%b %d %Y} : Total Hours = { int(elapsed_hours) } (threshold = {delete_after_hours}) - {project['path_with_namespace']}")
+    
+    if elapsed_hours > delete_after_hours:
+        logger.info(f"Stale repository found. Last Activity {lastActivity:%b %d %Y}  : Total Hours = { int(elapsed_hours) } (threshold = {delete_after_hours}) - {project['path_with_namespace']}")
+        shouldDelete = True
+
+    return shouldDelete
+# end is_project_stale
+
+check_env_vars()
+
+if(dry_run):
+   logger.info('In dry-run mode. No deletes will occur')
+
+delete_after_hours = int(delete_after_hours_string)
+logger.info("Delete projects after %i hours", delete_after_hours)
+
+clean_group(parent_group_id, "PARENT")
+
+logger.info("Gitlab clean up complete")

--- a/jobs/gitlab-delete-stale-projects/templates/cronjob.yaml
+++ b/jobs/gitlab-delete-stale-projects/templates/cronjob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec:
+  schedule: "{{ .Values.cron.schedule }}"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: {{ .Values.cron.historyLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+            env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.env.logLevel }}"
+            - name: DELETE_AFTER_HOURS
+              value: "{{ .Values.env.deleteAfterInHours }}"
+            - name: DRY_RUN
+              value: "{{ .Values.env.dryRun }}"
+            - name: GITLAB_API_URL
+              value: {{ .Values.env.gitlabApiUrl }}
+            - name: PARENT_GROUP_ID
+              value: "{{ .Values.env.parentGroupId }}"
+            - name: GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: GITLAB_PERSONAL_ACCESS_TOKEN
+                  name: {{ .Values.env.secret.name }}
+            imagePullPolicy: Always
+            name: {{ .Values.name }}
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          restartPolicy: OnFailure
+status: {}

--- a/jobs/gitlab-delete-stale-projects/templates/secret.yaml
+++ b/jobs/gitlab-delete-stale-projects/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.generateSecret }}
+apiVersion: v1
+stringData:
+  GITLAB_PERSONAL_ACCESS_TOKEN: {{ .Values.env.secret.personalAccessToken }}
+kind: Secret
+metadata:
+  name: {{ .Values.env.secret.name }}
+type: Opaque
+{{- end }}

--- a/jobs/gitlab-delete-stale-projects/values.yaml
+++ b/jobs/gitlab-delete-stale-projects/values.yaml
@@ -1,7 +1,7 @@
 name: gitlab-cleanup
 
 image:
-  name: "quay.io/mcanoy/gitlab-cleanup" # "quay.io/rht-labs/omp-gitlab-cleanup"
+  name: "quay.io/redhat-cop/gitlab-cleanup"
   tag: "master" # This is intended to be overridden by the parent Helm chart.
 
 generateSecret: false # set true if you want to create the secret data file.
@@ -10,10 +10,10 @@ env:
   secret:
     name: secret-gitlab-info # cronjob references this secret
     personalAccessToken: xxxx # real value needed if useSecret=true
-  gitlabApiUrl: http://gitlab.ca # real value needed if useSecret=true
-  parentGroupId: 6 # real value needed if useSecret=true
-  deleteAfterInHours: 876000
-  dryRun: TRUE
+  gitlabApiUrl: http://gitlab.ca 
+  parentGroupId: 6 # top level group to search
+  deleteAfterInHours: 876000 # 1 year
+  dryRun: TRUE # set this to false to delete something
   logLevel: DEBUG
 
 cron:

--- a/jobs/gitlab-delete-stale-projects/values.yaml
+++ b/jobs/gitlab-delete-stale-projects/values.yaml
@@ -1,0 +1,21 @@
+name: gitlab-cleanup
+
+image:
+  name: "quay.io/mcanoy/gitlab-cleanup" # "quay.io/rht-labs/omp-gitlab-cleanup"
+  tag: "master" # This is intended to be overridden by the parent Helm chart.
+
+generateSecret: false # set true if you want to create the secret data file.
+
+env:
+  secret:
+    name: secret-gitlab-info # cronjob references this secret
+    personalAccessToken: xxxx # real value needed if useSecret=true
+  gitlabApiUrl: http://gitlab.ca # real value needed if useSecret=true
+  parentGroupId: 6 # real value needed if useSecret=true
+  deleteAfterInHours: 876000
+  dryRun: TRUE
+  logLevel: DEBUG
+
+cron:
+  schedule: "1 0 * * *"
+  historyLimit: 5


### PR DESCRIPTION
#### What is this PR About?
Adds a cronjob that can delete stale gitlab groups and projects. This includes a github action to build and deploy the action to quay.io. 

The job takes a group id and checks its group and sub groups for projects that are older than 'x' amount of hours. If older, then they are deleted. If all of the sub group projects are deleted then the group is also deleted. 
- The parent group can never be deleted
- The job searches for `DO_NOT_DELETE` in the group and project descriptions and tag_list. If found then the group / project will not be deleted
- Provides a dry-run capability that will not delete anything but only log out what would have been deleted (on by default)
- provides a github action to build the container for this job. Builds a container labeled with the git sha when pushing to master as well as labeling it master. 
- provides a github action to tag the container on release with the release version and also latest. 
- **requires** set of a quay.io repo for `gitlab-cleanup` with appropriate bot user / pass and access

#### How do we test this?

A couple of options:

docker locally 

```
docker build . -t gitlab-clean
docker run -e DRY_RUN=true -e PARENT_GROUP_ID=-10 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com -e DELETE_AFTER_HOURS=240000 -e LOG_LEVEL=DEBUG gitlab-clean
```

from my quay:

Set a group and projects to play with (not deletes by default). Check the Readme here for full config options.

```
helm template . \
  --set env.secret.name=my-openshift-secret-ref \
  --set env.secret.gitlabApiUrl=https//my.gitlab.base.com \
  --set env.secret.personalAccessToken=bot-token-value \
  --set env.secret.parentRepoId=-1 \
| oc apply -f - -n target-namespace
```

cc: @redhat-cop/casl, @oybed, @pabrahamsson 
