### PR TITLE
Replace jenkins base in prune jobs

### DIFF
--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -127,12 +127,12 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+  value: "quay.io/openshift/origin-cli:latest"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v3.11"
+  value: "v4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -127,7 +127,7 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "quay.io/openshift/origin-cli:latest"
+  value: "quay.io/openshift/origin-cli"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -107,7 +107,7 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "quay.io/openshift/origin-cli:latest"
+  value: "quay.io/openshift/origin-cli"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -107,12 +107,12 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+  value: "quay.io/openshift/origin-cli:latest"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v3.11"
+  value: "v4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false


### PR DESCRIPTION
#### What is this PR About?
This replaces the image that two of our prune jobs use in order to. Went with the publicly hosted image on quay instead of the `ose-client` image in the redhat registry as that image currently requires additional credentials. Happy to change if we think that's a better approach.

#### How do we test this?
Run jobs and verify that the same result is acheived.

cc: @redhat-cop/casl
