### PR TITLE
Fix cli tag

### DIFF
--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -127,12 +127,12 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+  value: "quay.io/openshift/origin-cli:latest"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v3.11"
+  value: "v4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -127,7 +127,7 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "quay.io/openshift/origin-cli:latest"
+  value: "quay.io/openshift/origin-cli"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."

--- a/jobs/cronjob-prune-builds-deployments.yml
+++ b/jobs/cronjob-prune-builds-deployments.yml
@@ -132,7 +132,7 @@ parameters:
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v4.4"
+  value: "4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -107,7 +107,7 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "quay.io/openshift/origin-cli:latest"
+  value: "quay.io/openshift/origin-cli"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -112,7 +112,7 @@ parameters:
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v4.4"
+  value: "4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -107,12 +107,12 @@ parameters:
   displayName: "Image"
   description: "Image to use for the container."
   required: true
-  value: "registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7"
+  value: "quay.io/openshift/origin-cli:latest"
 - name: "IMAGE_TAG"
   displayName: "Image Tag"
   description: "Image Tag to use for the container."
   required: true
-  value: "v3.11"
+  value: "v4.4"
 - name: STARTING_DEADLINE_SECONDS
   description: Set the startingDeadlineSeconds for the cronjob
   required: false


### PR DESCRIPTION
#### What is this PR About?
This changes the tag from v4.4 to 4.4 that origin-cli uses in quay

#### How do we test this?
Run job and verify that it starts

cc: @redhat-cop/casl
