### PR TITLE
Add optional notifier for gitlab-cleanup job when deletes occur

### DIFF
--- a/.github/workflows/gitlab-del-projects-container-build.yaml
+++ b/.github/workflows/gitlab-del-projects-container-build.yaml
@@ -3,7 +3,7 @@ name: Gitlab Delete Projects Container
 on:
   push:
     branches:
-      - del-notify
+      - master
     paths:
       - images/gitlab-delete-stale-projects/**
       - .github/workflows/gitlab-del-projects-container-build.yaml
@@ -20,10 +20,10 @@ jobs:
     - name: Login quay.io
       run: echo ${{ secrets.QUAY_PASSWORD }} | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
     - name: Build Container
-      run: docker build images/gitlab-delete-stale-projects -t quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+      run: docker build images/gitlab-delete-stale-projects -t quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
     - name: Push Container 
-      run: docker push quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
+      run: docker push quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
     - name: Tag Latest
-      run: docker tag quay.io/mcanoy/gitlab-cleanup:${{ github.sha }} quay.io/mcanoy/gitlab-cleanup:master
+      run: docker tag quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }} quay.io/redhat-cop/gitlab-cleanup:master
     - name: Push branch tag
-      run: docker push quay.io/mcanoy/gitlab-cleanup:master
+      run: docker push quay.io/redhat-cop/gitlab-cleanup:master

--- a/.github/workflows/gitlab-del-projects-container-build.yaml
+++ b/.github/workflows/gitlab-del-projects-container-build.yaml
@@ -3,7 +3,7 @@ name: Gitlab Delete Projects Container
 on:
   push:
     branches:
-      - master
+      - del-notify
     paths:
       - images/gitlab-delete-stale-projects/**
       - .github/workflows/gitlab-del-projects-container-build.yaml
@@ -20,10 +20,10 @@ jobs:
     - name: Login quay.io
       run: echo ${{ secrets.QUAY_PASSWORD }} | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
     - name: Build Container
-      run: docker build images/gitlab-delete-stale-projects -t quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
+      run: docker build images/gitlab-delete-stale-projects -t quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
     - name: Push Container 
-      run: docker push quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }}
+      run: docker push quay.io/mcanoy/gitlab-cleanup:${{ github.sha }}
     - name: Tag Latest
-      run: docker tag quay.io/redhat-cop/gitlab-cleanup:${{ github.sha }} quay.io/redhat-cop/gitlab-cleanup:master
+      run: docker tag quay.io/mcanoy/gitlab-cleanup:${{ github.sha }} quay.io/mcanoy/gitlab-cleanup:master
     - name: Push branch tag
-      run: docker push quay.io/redhat-cop/gitlab-cleanup:master
+      run: docker push quay.io/mcanoy/gitlab-cleanup:master

--- a/charts/cronjob-gitlab-delete-projects/README.md
+++ b/charts/cronjob-gitlab-delete-projects/README.md
@@ -7,9 +7,23 @@ A cronjob that enables OpenShift to delete Gitlab projects that have become stal
 The cronjob will not delete in the follow cases:
 
 1. A group with the text `DO_NOT_DELETE` in the description will not delete the group, any subgroup and projects in the group and subgroups.
-2.  A project wit the text `DO_NOT_DELETE` in the description or a tag `DO_NOT_DELETE` in the tag list.
+2. A project wit the text `DO_NOT_DELETE` in the description or a tag `DO_NOT_DELETE` in the tag list.
 
 **Caution:** this jobs performs hard deletes. The actual deletion policy is influenced by overarching settings in Gitlab.
+
+## Notification / Hook
+
+This job has the ability to notify applications via a webhook. Specify the url to post to and the value of the secret header `x-cleanup-token` for the request to be invoked.
+
+The json payload will look like
+
+```
+{
+  "event_name": "project_deleted", # or group_deleted
+  "group_id": 1424, # only set if group was deleted
+  "project" { ...} # the full gitlab project structure, only set if project was deleted
+}
+```
 
 ## Using This Chart
 
@@ -54,3 +68,5 @@ The following variables maybe configured.
 | `env.gitlabApiUrl`  | cronjob | The url of the gitlab instance |
 | `env.secret.personalAccessToken`  | secret | The personal access token for the user accessing gitlab. Bot recommended |
 | `env.parentGroupId`  | cronjob | Group ID of the GitLab (sub)group to look for projects to delete. |
+| `env.secret.notificationToken` | secret | The access token for the notification application |
+| `env.notificationUrl` | cronjob | The url to notify when a delete has occurred | 

--- a/charts/cronjob-gitlab-delete-projects/README.md
+++ b/charts/cronjob-gitlab-delete-projects/README.md
@@ -13,7 +13,7 @@ The cronjob will not delete in the follow cases:
 
 ## Notification / Hook
 
-This job has the ability to notify applications via a webhook. Specify the url to post to and the value of the secret header `x-cleanup-token` for the request to be invoked.
+This job has the ability to notify applications via a webhook. Specify the url to post to and the value of the secret header `x-notification-token` for the request to be invoked.
 
 The json payload will look like
 

--- a/charts/cronjob-gitlab-delete-projects/templates/cronjob.yaml
+++ b/charts/cronjob-gitlab-delete-projects/templates/cronjob.yaml
@@ -25,10 +25,17 @@ spec:
               value: {{ .Values.env.gitlabApiUrl }}
             - name: PARENT_GROUP_ID
               value: "{{ .Values.env.parentGroupId }}"
+            - name: NOTIFICATION_URL
+              value: "{{ .Values.env.notificationUrl }}"
             - name: GIT_TOKEN
               valueFrom:
                 secretKeyRef:
                   key: GITLAB_PERSONAL_ACCESS_TOKEN
+                  name: {{ .Values.env.secret.name }}
+            - name: NOTIFICATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: NOTIFICATION_TOKEN
                   name: {{ .Values.env.secret.name }}
             imagePullPolicy: Always
             name: {{ .Values.name }}

--- a/charts/cronjob-gitlab-delete-projects/templates/secret.yaml
+++ b/charts/cronjob-gitlab-delete-projects/templates/secret.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 stringData:
   GITLAB_PERSONAL_ACCESS_TOKEN: {{ .Values.env.secret.personalAccessToken }}
+  NOTIFICATION_TOKEN: {{ .Values.env.secret.notificationToken }}
 kind: Secret
 metadata:
   name: {{ .Values.env.secret.name }}

--- a/charts/cronjob-gitlab-delete-projects/values.yaml
+++ b/charts/cronjob-gitlab-delete-projects/values.yaml
@@ -9,7 +9,8 @@ generateSecret: false # set true if you want to create the secret data file.
 env:
   secret:
     name: secret-gitlab-info # cronjob references this secret
-    personalAccessToken: xxxx # real value needed if useSecret=true
+    personalAccessToken: xxxx # real value needed if generateSecret=true
+    notificationToken: yyyy # real value needed if generateSecret=true
   gitlabApiUrl: http://gitlab.ca 
   parentGroupId: 6 # top level group to search
   deleteAfterInHours: 876000 # 1 year


### PR DESCRIPTION
#### What is this PR About?

Updates the gitlab-cleanup job to add an additional feature. Notifications / hooks. Each time the job either deletes a group or project it has the ability to optionally make an http post to an application that can act on that information as it sees fit.




#### How do we test this?
Setup an app that can accept post urls.

Create a group and subgroup and project in gitlab. Configure the gitlab-delete-projects job with the necessary info to run the job. Something like 

```
name: gitlab-cleanup

image:
  name: "quay.io/redhat-cop/gitlab-cleanup"
  tag: "master" # This is intended to be overridden by the parent Helm chart.

generateSecret: true # set true if you want to create the secret data file.

env:
  secret:
    name: gitlab-cleanup # cronjob references this secret
    personalAccessToken: xxx
    notificationToken: secrettoken # real value needed if generateSecret=true
  gitlabApiUrl: https://xxx.com/
  parentGroupId: -1 # top level group to search
  deleteAfterInHours: 120 # delete anything older than 12 hours
  dryRun: TRUE # set this to false to delete something
  logLevel: DEBUG
  notificationUrl: https://webhook.url

cron:
  schedule: "0/4 * * * *"
  historyLimit: 5
```

Wait for the cronjob to kick off. 

cc: @redhat-cop/casl, @tylerauerbeck, @pabrahamsson, @oybed 
