### PR TITLE
certificate-authority param is added

### DIFF
--- a/charts/cronjob-prune-images/templates/cronjob.yaml
+++ b/charts/cronjob-prune-images/templates/cronjob.yaml
@@ -16,8 +16,8 @@ spec:
           - command:
             - /bin/bash
             - -c
-            - oc adm prune images --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS
-              --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm
+            - oc adm prune images --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt 
+              --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm
             env:
             - name: IMAGE_PRUNE_KEEP_TAG_REVISIONS
               value: {{ .Values.image_prune_keep_tag_revisions }}

--- a/charts/cronjob-prune-images/values.yaml
+++ b/charts/cronjob-prune-images/values.yaml
@@ -1,8 +1,8 @@
 failed_jobs_history_limit: "5"
-image: registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
+image: quay.io/openshift/origin-cli
 image_prune_keep_tag_revisions: "3"
 image_prune_keep_younger_than: 1h0m0s
-image_tag: v3.11
+image_tag: 4.4
 job_name: cronjob-prune-images
 job_service_account: pruner
 namespace: cluster-ops

--- a/jobs/cronjob-prune-images.yml
+++ b/jobs/cronjob-prune-images.yml
@@ -27,8 +27,8 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - oc adm prune images --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS
-                --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm
+              - oc adm prune images --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt 
+                --keep-tag-revisions=$IMAGE_PRUNE_KEEP_TAG_REVISIONS --keep-younger-than=$IMAGE_PRUNE_KEEP_YOUNGER_THAN --confirm
               env:
               - name: IMAGE_PRUNE_KEEP_TAG_REVISIONS
                 value: "${IMAGE_PRUNE_KEEP_TAG_REVISIONS}"


### PR DESCRIPTION
#### What is this PR About?
`--certificate-authority` param is added to avoid following error in image pruner job:
`error: failed to ping registry image-registry.openshift-image-registry.svc:5000: Get https://image-registry.openshift-image-registry.svc:5000/: x509: certificate signed by unknown authority`

#### How do we test this?
Run `oc adm prune images --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt  --keep-tag-revisions=3 --keep-younger-than=60m  --confirm` inside a pod running in Openshift 4.4

cc: @redhat-cop/casl
