### PR TITLE
Use namespace to identify name for clusterrole.

### DIFF
--- a/charts/cronjob-aws-ocp-snap/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-aws-ocp-snap/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-aws-ocp-snap
-  name: system:pvc-reader
+  name: {{ .Values.namespace }}-pvc-reader
 roleRef:
   name: pvc-reader
 subjects:

--- a/charts/cronjob-ldap-group-sync-secure/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-ldap-group-sync-secure
-  name: system:ldap-group-syncers
+  name: {{ .Values.namespace }}-ldap-group-syncers
 roleRef:
   name: ldap-group-syncer
 subjects:

--- a/charts/cronjob-ldap-group-sync/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-ldap-group-sync
-  name: system:ldap-group-syncers
+  name: {{ .Values.namespace }}-ldap-group-syncers
 roleRef:
   name: ldap-group-syncer
 subjects:

--- a/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-builds-deployments
-  name: system:build-pruners
+  name: {{ .Values.namespace }}-build-pruners
 roleRef:
   name: cluster-admin
 subjects:

--- a/charts/cronjob-prune-images/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-images/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-images
-  name: system:image-pruners
+  name: {{ .Values.namespace }}-image-pruners
 roleRef:
   name: cluster-admin
 subjects:

--- a/charts/cronjob-prune-projects/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-projects/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-projects
-  name: system:project-pruners
+  name: {{ .Values.namespace }}-project-pruners
 roleRef:
   name: cluster-admin
 subjects:


### PR DESCRIPTION
#### What is this PR About?
Fixes #60 and helps identify resources added to a cluster by this project more clearly.
I'm open to suggestions if using the namespace name as the prefix is undesireable.

#### How do we test this?
install cronjobs via templates or helm and verify the clusterrole no longer has the "system:" prefix.

cc: @redhat-cop/casl
