### PR TITLE
Make example namespace for helm charts consistent.

### DIFF
--- a/charts/cluster-descheduler/values.yaml
+++ b/charts/cluster-descheduler/values.yaml
@@ -8,7 +8,7 @@ max_pods: "0"
 min_cpu: "0"
 min_mem: "0"
 min_pods: "0"
-namespace: kube-system
+namespace: cluster-ops
 node_threshold: "0"
 remove_dups: "False"
 schedule: '@hourly'

--- a/charts/cronjob-aws-ocp-snap/values.yaml
+++ b/charts/cronjob-aws-ocp-snap/values.yaml
@@ -5,7 +5,7 @@ failed_jobs_history_limit: "5"
 job_name: cronjob-ebs-snaphost
 job_service_account: ebs-snap-creator
 name: cronjob-aws-ocp-snap
-namespace: cluster-maintenance
+namespace: cluster-ops
 nspace: '# TODO: must define a default value for .nspace'
 schedule: '@daily'
 success_jobs_history_limit: "5"

--- a/charts/cronjob-ldap-group-sync-secure/values.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/values.yaml
@@ -19,6 +19,6 @@ ldap_url: '# TODO: must define a default value for .ldap_url'
 ldap_user_name_attributes: '["uid"]'
 ldap_user_uid_attribute: dn
 ldap_users_search_base: cn=users,cn=accounts,dc=myorg,dc=example,dc=com
-namespace: openshift-cluster-ops
+namespace: cluster-ops
 schedule: '@hourly'
 success_jobs_history_limit: "5"

--- a/charts/cronjob-ldap-group-sync/values.yaml
+++ b/charts/cronjob-ldap-group-sync/values.yaml
@@ -16,6 +16,6 @@ ldap_url: '# TODO: must define a default value for .ldap_url'
 ldap_user_name_attributes: '["uid"]'
 ldap_user_uid_attribute: dn
 ldap_users_search_base: cn=users,cn=accounts,dc=myorg,dc=example,dc=com
-namespace: openshift-cluster-ops
+namespace: cluster-ops
 schedule: '@hourly'
 success_jobs_history_limit: "5"

--- a/charts/cronjob-prune-projects/values.yaml
+++ b/charts/cronjob-prune-projects/values.yaml
@@ -4,7 +4,7 @@ failed_jobs_history_limit: "5"
 job_name: cronjob-prune-projects
 job_service_account: pruner
 name: prune-ocp-projects
-namespace: cluster-maintenance
+namespace: cluster-ops
 project_exclude_system: default kube-public kube-service-catalog kube-system management-infra
   openshift openshift-ansible-service-broker openshift-infra openshift-logging openshift-node
   openshift-sdn openshift-template-service-broker openshift-web-console openshift-console


### PR DESCRIPTION
#### What is this PR About?
some places namespace was "openshift-cluster-ops" others "cluster-ops" others "cluster-maintenance".

This just sets them to "cluster-ops" forsaking the "openshift" prefix that should really be restricted to directly supported OCP components.

Also, the cluster-descheduler was set to kube-system.  I did switch that one as well, but would like someone to confirm that is ok.  Not sure if that requires being in kube-system for some particular functionality.  

#### How do we test this?
Install charts with helm.

cc: @redhat-cop/casl
