### PR TITLE
Hard code system namespaces, match by wildcard expansion.

### DIFF
--- a/charts/cronjob-prune-projects/values.yaml
+++ b/charts/cronjob-prune-projects/values.yaml
@@ -5,21 +5,7 @@ job_name: cronjob-prune-projects
 job_service_account: pruner
 name: prune-ocp-projects
 namespace: cluster-ops
-project_exclude_system: default kube-public kube-service-catalog kube-system management-infra
-  openshift openshift-ansible-service-broker openshift-infra openshift-logging openshift-node
-  openshift-sdn openshift-template-service-broker openshift-web-console openshift-console
-  openshift-metrics-server openshift-monitoring openshift-apiserver openshift-apiserver-operator
-  openshift-authentication openshift-authentication-operator openshift-cluster-machine-approver
-  openshift-cluster-node-tuning-operator openshift-cluster-samples-operator openshift-cluster-storage-operator
-  openshift-cluster-version openshift-config openshift-config-managed openshift-console-operator
-  openshift-controller-manager openshift-controller-manager-operator openshift-dns
-  openshift-dns-operator openshift-etcd openshift-image-registry openshift-infra openshift-ingress
-  openshift-ingress-operator openshift-kube-apiserver openshift-kube-apiserver-operator
-  openshift-kube-controller-manager openshift-kube-controller-manager-operator openshift-kube-scheduler
-  openshift-kube-scheduler-operator openshift-machine-api openshift-machine-config-operator
-  openshift-marketplace openshift-multus openshift-network-operator openshift-node
-  openshift-operator-lifecycle-manager openshift-operators openshift-sdn openshift-service-ca
-  openshift-service-ca-operator openshift-service-catalog-apiserver-operator openshift-service-catalog-controller-manager-operator
+project_exclude_system: management-infra istio-system cluster-ops
 project_exclude_user: '# TODO: must define a default value for .project_exclude_user'
 schedule: '@hourly'
 source_repository_ref: master

--- a/charts/cronjob-prune-projects/values.yaml
+++ b/charts/cronjob-prune-projects/values.yaml
@@ -5,7 +5,7 @@ job_name: cronjob-prune-projects
 job_service_account: pruner
 name: prune-ocp-projects
 namespace: cluster-ops
-project_exclude_system: management-infra istio-system cluster-ops
+project_exclude_system: cluster-ops
 project_exclude_user: '# TODO: must define a default value for .project_exclude_user'
 schedule: '@hourly'
 source_repository_ref: master

--- a/images/prune-ocp-projects/include/prune-ocp-projects.sh
+++ b/images/prune-ocp-projects/include/prune-ocp-projects.sh
@@ -24,6 +24,15 @@ do
 done
 
 # Eliminate the "System projects"
+for project in "${!projects[@]}";
+do
+  if [[ "$project" == "openshift"*  || "$project" == "kube"* || "$project" == "default" ]];
+  then
+    unset projects["${project}"]
+  fi
+done
+
+# Eliminate the "User-System projects"
 if [ -n "${PROJECT_EXCLUDE_SYSTEM}" ];
 then
   for project in ${PROJECT_EXCLUDE_SYSTEM};

--- a/jobs/cronjob-prune-projects.yaml
+++ b/jobs/cronjob-prune-projects.yaml
@@ -132,7 +132,7 @@ parameters:
 - name: PROJECT_EXCLUDE_SYSTEM
   displayName: System projects to exclude from the Prune Job
   description: System projects that should not be deleted
-  value: default kube-public kube-service-catalog kube-system management-infra openshift openshift-ansible-service-broker openshift-infra openshift-logging openshift-node openshift-sdn openshift-template-service-broker openshift-web-console openshift-console openshift-metrics-server openshift-monitoring openshift-apiserver openshift-apiserver-operator openshift-authentication openshift-authentication-operator openshift-cluster-machine-approver openshift-cluster-node-tuning-operator openshift-cluster-samples-operator openshift-cluster-storage-operator openshift-cluster-version openshift-config openshift-config-managed openshift-console-operator openshift-controller-manager openshift-controller-manager-operator openshift-dns openshift-dns-operator openshift-etcd openshift-image-registry openshift-infra openshift-ingress openshift-ingress-operator openshift-kube-apiserver openshift-kube-apiserver-operator openshift-kube-controller-manager openshift-kube-controller-manager-operator openshift-kube-scheduler openshift-kube-scheduler-operator openshift-machine-api openshift-machine-config-operator openshift-marketplace openshift-multus openshift-network-operator openshift-node openshift-operator-lifecycle-manager openshift-operators openshift-sdn openshift-service-ca openshift-service-ca-operator openshift-service-catalog-apiserver-operator openshift-service-catalog-controller-manager-operator
+  value: management-infra istio-system cluster-ops
   required: true
 - name: PROJECT_EXCLUDE_USER
   displayName: User defined projects to exclude from the Prune Job


### PR DESCRIPTION
#### What is this PR About?
Fixes #69 Identifies openshift* , kube*, and default namespaces as hard coded in script.  Users can still omit more with PROJECT_EXCLUDE_SYSTEM

#### How do we test this?
Run prune images command and verify no system projects are touched.

cc: @redhat-cop/casl
