### PR TITLE
apiVersion fixes and setting unique object names so charts can be run…

### DIFF
--- a/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
@@ -10,4 +10,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
 userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.prune_type }}-{{ .Values.job_service_account }}

--- a/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-builds-deployments
-  name: {{ .Values.namespace }}-build-pruners
+  name: {{ .Values.namespace }}-{{ .Values.prune_type }}-pruners
 roleRef:
   name: cluster-admin
 subjects:

--- a/charts/cronjob-prune-builds-deployments/templates/cronjob.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/cronjob.yaml
@@ -31,8 +31,8 @@ spec:
             name: {{ .Values.job_name }}-{{ .Values.prune_type }}
           dnsPolicy: ClusterFirst
           restartPolicy: Never
-          serviceAccount: {{ .Values.job_service_account }}
-          serviceAccountName: {{ .Values.job_service_account }}
+          serviceAccount: {{ .Values.prune_type }}-{{ .Values.job_service_account }}
+          serviceAccountName: {{ .Values.prune_type }}-{{ .Values.job_service_account }}
           terminationGracePeriodSeconds: 30
   schedule: {{ .Values.schedule }}
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}

--- a/charts/cronjob-prune-builds-deployments/templates/serviceaccount.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/serviceaccount.yaml
@@ -3,4 +3,4 @@ kind: ServiceAccount
 metadata:
   labels:
     template: cronjob-prune-builds-deployments
-  name: {{ .Values.job_service_account }}
+  name: {{ .Values.prune_type }}-{{ .Values.job_service_account }}

--- a/charts/cronjob-prune-builds-deployments/values.yaml
+++ b/charts/cronjob-prune-builds-deployments/values.yaml
@@ -2,7 +2,7 @@ failed_jobs_history_limit: "5"
 image: registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
 image_tag: v3.11
 job_name: cronjob-prune-resources
-job_service_account: pruner
+job_service_account: {{ .Values.prune_type }}-pruner
 keep_complete: "5"
 keep_failed: "1"
 keep_younger_than: 60m

--- a/charts/cronjob-prune-images/values.yaml
+++ b/charts/cronjob-prune-images/values.yaml
@@ -4,7 +4,7 @@ image_prune_keep_tag_revisions: "3"
 image_prune_keep_younger_than: 1h0m0s
 image_tag: 4.4
 job_name: cronjob-prune-images
-job_service_account: pruner
+job_service_account: image-pruner
 namespace: cluster-ops
 schedule: 0 0 * * *
 success_jobs_history_limit: "5"

--- a/charts/cronjob-prune-projects/templates/buildconfig.yaml
+++ b/charts/cronjob-prune-projects/templates/buildconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   annotations:
@@ -18,6 +18,7 @@ spec:
     git:
       ref: {{ .Values.source_repository_ref }}
       uri: {{ .Values.source_repository_url }}
+    type: Git
   strategy:
     dockerStrategy:
       from:

--- a/charts/cronjob-prune-projects/templates/cronjob.yaml
+++ b/charts/cronjob-prune-projects/templates/cronjob.yaml
@@ -31,5 +31,5 @@ spec:
           serviceAccount: {{ .Values.job_service_account }}
           serviceAccountName: {{ .Values.job_service_account }}
           terminationGracePeriodSeconds: 30
-  schedule: {{ .Values.schedule }}
+  schedule: "{{ .Values.schedule }}"
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}

--- a/charts/cronjob-prune-projects/templates/imagestream.yaml
+++ b/charts/cronjob-prune-projects/templates/imagestream.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   annotations:

--- a/charts/cronjob-prune-projects/values.yaml
+++ b/charts/cronjob-prune-projects/values.yaml
@@ -2,7 +2,7 @@ base_image: centos:7
 context_dir: images/prune-ocp-projects
 failed_jobs_history_limit: "5"
 job_name: cronjob-prune-projects
-job_service_account: pruner
+job_service_account: project-pruner
 name: prune-ocp-projects
 namespace: cluster-ops
 project_exclude_system: default kube-public kube-service-catalog kube-system management-infra


### PR DESCRIPTION
… and managed separately from each other.

#### What is this PR About?
A couple apiVersion  and other field details need for Helm charts to run correctly.
Split up object names by vars for build/deployments so they can be installed with independent resources (not sharing the same serviceaccount)

#### How do we test this?
Run each of the charts by helm install
(version.BuildInfo{Version:"v3.2.4", GitCommit:"0ad800ef43d3b826f31a5ad8dfbb4fe05d143688", GitTreeState:"clean", GoVersion:"go1.13.12"})

cc: @redhat-cop/casl
