### PR TITLE
quotes added to avoid error

### DIFF
--- a/charts/cronjob-ldap-group-sync/templates/clusterrole.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/cronjob-ldap-group-sync/templates/cronjob.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/cronjob.yaml
@@ -39,5 +39,5 @@ spec:
           - name: ldap-bind-password
             secret:
               secretName: {{ .Values.ldap_bind_password_secret }}
-  schedule: {{ .Values.schedule }}
+  schedule: '{{ .Values.schedule }}'
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}

--- a/charts/cronjob-ldap-group-sync/templates/cronjob.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/cronjob.yaml
@@ -39,5 +39,5 @@ spec:
           - name: ldap-bind-password
             secret:
               secretName: {{ .Values.ldap_bind_password_secret }}
-  schedule: '{{ .Values.schedule }}'
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}


### PR DESCRIPTION
#### What is this PR About?
I was getting the following error when I try to `helm template..`

```
Error: YAML parse error on cronjob-ldap-group-sync/templates/cronjob.yaml: error converting YAML to JSON: yaml: line 42: found character that cannot start any token
```

The quotes are there to avoid this.

#### How do we test this?
`helm template -f values.yaml . `

cc: @redhat-cop/casl
