### PR TITLE
rbac apiVersion updated

### DIFF
--- a/charts/cluster-descheduler/templates/clusterrole.yaml
+++ b/charts/cluster-descheduler/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/cronjob-aws-ocp-snap/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-aws-ocp-snap/templates/clusterrolebinding.yaml
@@ -1,13 +1,14 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-aws-ocp-snap
   name: {{ .Values.namespace }}-pvc-reader
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: pvc-reader
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-ldap-group-sync-secure/templates/clusterrole.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/cronjob-ldap-group-sync-secure/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 groupNames: null
 kind: ClusterRoleBinding
 metadata:
@@ -6,9 +6,10 @@ metadata:
     template: cronjob-ldap-group-sync-secure
   name: {{ .Values.namespace }}-ldap-group-syncers
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: ldap-group-syncer
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-ldap-group-sync-secure/templates/configmap.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
       userUIDAttribute: "{{ .Values.ldap_user_uid_attribute }}"
       tolerateMemberNotFoundErrors: true
       tolerateMemberOutOfScopeErrors: true
-  whitelist.txt: {{ .Values.ldap_groups_whitelist }}
+  whitelist.txt: {{ .Values.ldap_groups_whitelist | quote }}
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/cronjob-ldap-group-sync/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 groupNames: null
 kind: ClusterRoleBinding
 metadata:
@@ -6,9 +6,10 @@ metadata:
     template: cronjob-ldap-group-sync
   name: {{ .Values.namespace }}-ldap-group-syncers
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: ldap-group-syncer
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-ldap-group-sync/templates/configmap.yaml
+++ b/charts/cronjob-ldap-group-sync/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
       userUIDAttribute: "{{ .Values.ldap_user_uid_attribute }}"
       tolerateMemberNotFoundErrors: true
       tolerateMemberOutOfScopeErrors: true
-  whitelist.txt: {{ .Values.ldap_groups_whitelist }}
+  whitelist.txt: {{ .Values.ldap_groups_whitelist | quote }}
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-builds-deployments/templates/clusterrolebinding.yaml
@@ -1,13 +1,14 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-builds-deployments
   name: {{ .Values.namespace }}-{{ .Values.prune_type }}-pruners
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: cluster-admin
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.prune_type }}-{{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.prune_type }}-{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-prune-images/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-images/templates/clusterrolebinding.yaml
@@ -1,13 +1,14 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-images
   name: {{ .Values.namespace }}-image-pruners
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: cluster-admin
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-prune-projects/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-projects/templates/clusterrolebinding.yaml
@@ -1,13 +1,14 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     template: cronjob-prune-projects
   name: {{ .Values.namespace }}-project-pruners
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: cluster-admin
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}

--- a/charts/cronjob-prune-tekton-pipelinerun/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-tekton-pipelinerun/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/charts/cronjob-prune-tekton-pipelinerun/templates/clusterrolebinding.yaml
+++ b/charts/cronjob-prune-tekton-pipelinerun/templates/clusterrolebinding.yaml
@@ -5,9 +5,10 @@ metadata:
     template: cronjob-prune-tekton-pipelinerun
   name: {{ .Values.namespace }}-tekton-pipelinerun-pruners
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   name: cluster-admin
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.job_service_account }}
-userNames:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.job_service_account }}
+  namespace: {{ .Values.namespace }}


### PR DESCRIPTION
#### What is this PR About?
RBAC API has changed from `authorization.openshift.io/v1`to `rbac.authorization.k8s.io/v1`
Also, `quote` added to whitelist variable in case of an empty value. 

#### How do we test this?
`helm template..` or `helm install..` towards any of the charts..

cc: @redhat-cop/casl
