### PR TITLE
fix notification when deleting gitlab projects and groups

### DIFF
--- a/charts/cronjob-gitlab-delete-projects/README.md
+++ b/charts/cronjob-gitlab-delete-projects/README.md
@@ -69,4 +69,4 @@ The following variables maybe configured.
 | `env.secret.personalAccessToken`  | secret | The personal access token for the user accessing gitlab. Bot recommended |
 | `env.parentGroupId`  | cronjob | Group ID of the GitLab (sub)group to look for projects to delete. |
 | `env.secret.notificationToken` | secret | The access token for the notification application |
-| `env.notificationUrl` | cronjob | The url to notify when a delete has occurred | 
+| `env.notificationUrl` | cronjob | The url to notify when a delete has occurred. Disabled during a dry run unless the token is set to `DRYRUN` | 

--- a/images/gitlab-delete-stale-projects/README.md
+++ b/images/gitlab-delete-stale-projects/README.md
@@ -15,3 +15,5 @@ To run:
 ```
 docker run -e DRY_RUN=true -e PARENT_GROUP_ID=-10 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com -e DELETE_AFTER_HOURS=240000 -e LOG_LEVEL=DEBUG gitlab-clean
 ```
+
+See the [chart doc](../../charts/cronjob-gitlab-delete-projects/README.md) for more configuration information.

--- a/images/gitlab-delete-stale-projects/gitlab-cleanup.py
+++ b/images/gitlab-delete-stale-projects/gitlab-cleanup.py
@@ -178,8 +178,13 @@ def notifyGroup(group_id):
     notify(None, group_id)
 
 def notify(project, group_id):
-    if notification_url is None or notification_token is None:
+    
+    if not notification_url or not notification_token:
         logger.debug("Notifications not configured")
+        return False
+
+    if dry_run and notification_token != 'DRYRUN':
+        logger.debug('Notification not sent during dry run. Set token to DRYRUN to enable dry run notifications');
         return False
     
     try:


### PR DESCRIPTION
#### What is this PR About?

This PR fixes an issue when using the job that deletes gitlab groups and projects. When not in `dry_run` mode, the notification will not occur because the method (delete_group, delete_project) will return before the notification is made. This change inverts the way the method gets returned. Now - if the method gets to the end it assumes success and returns `True`.

This also lists the notification url at start and indicates if a token is set (token not printed). The job will no longer error out if the notification url is not reachable.



#### How do we test this?

This can be tested against a gitlab instance that has groups and projects. Setting dry_run = true will not delete anything. Here is an example usage build and run 


```
docker build . -t gitlab-clean && docker run -e DRY_RUN=true -e PARENT_GROUP_ID=9999 -e GIT_TOKEN=xxxxx -e GITLAB_API_URL=https://gitlab.com/ -e DELETE_AFTER_HOURS=0 -e NOTIFICATION_URL=https://notification.url  -e NOTIFICATION_TOKEN=xxxx -e LOG_LEVEL=DEBUG gitlab-clean
```

cc: @redhat-cop/casl @oybed 
