### PR TITLE
Fix yaml parse error: @ cannot start a string

### DIFF
--- a/charts/cronjob-ldap-group-sync-secure/templates/cronjob.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/cronjob.yaml
@@ -44,5 +44,5 @@ spec:
           - name: ldap-bind-password
             secret:
               secretName: {{ .Values.ldap_bind_password_secret }}
-  schedule: {{ .Values.schedule }}
+  schedule: "{{ .Values.schedule }}"
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}

--- a/charts/cronjob-ldap-group-sync-secure/templates/cronjob.yaml
+++ b/charts/cronjob-ldap-group-sync-secure/templates/cronjob.yaml
@@ -44,5 +44,5 @@ spec:
           - name: ldap-bind-password
             secret:
               secretName: {{ .Values.ldap_bind_password_secret }}
-  schedule: "{{ .Values.schedule }}"
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}


### PR DESCRIPTION
Helm 3.5.0 (not tested with earlier versions)

#### What is this PR About?

The `schedule` var value is `@hourly`. The `@` produces this error:

> error converting YAML to JSON: yaml: line 47: found character that cannot start any token

Quoting the string fixes the issue.

#### How do we test this?

```
helm template cronjob-ldap-group-sync-secure . --debug
```

cc: @redhat-cop/casl
