### PR TITLE
Support pruning multiple Tekton pipelines

### DIFF
--- a/charts/cronjob-prune-tekton-pipelinerun/README.md
+++ b/charts/cronjob-prune-tekton-pipelinerun/README.md
@@ -1,0 +1,43 @@
+# Delete Tekton Pipelinruns Job
+
+A cronjob that enables OpenShift to delete Tekton Pipelineruns that have completed. The job will delete Pipelineruns above `NUM_TO_KEEP` in all namespaces (`^kube|^openshift|^default` are excluded). Individual pipelines can also be deleted through `PIPELINES` (use the following format: `"ns1/pipeline1 ns1/pipeline2 ns2/pipeline1"`).
+
+## Using This Chart
+
+This chart is geared toward Helm 3.
+
+1. Clone the target repo
+
+```
+git clone https://github.com/redhat-cop/openshift-management.git
+```
+
+2. Change into ths job's directory
+
+```
+cd openshift-management/charts/cronjob-prune-tekton-pipelinerun
+```
+
+3. Deploy using the follow Helm command:
+
+```
+helm template prune-tekton-pipelinerun . \
+  --set namespace=prune-jobs \
+  --set num_to_keep=5 \
+  --set pipelines="ns1/pipeline1 ns2/pipeline1"
+| oc apply -f - -n target-namespace
+```
+
+The following variables maybe configured.
+
+| Variable  | Used by | Usage | Default |
+|---|---|--|--|
+| `namespace`  | cronjob | The namespace where to install | `labs-ci-cd` |
+| `job_name`  | cronjob | The name of the cronjob| `cronjob-prune-tekton-pipelinerun` |
+| `schedule`  | cronjob | The cron schedule | `"*/30 * * * *"` |
+| `num_to_keep`  | cronjob | The number of pipelineruns to retain (per pipeline). | `10` |
+| `pipelines`  | cronjob | If set, then only these pipelines will be pruned. Should use format `namespace1/pipeline1`. Multiple pipelines are supported, use space delimited pipelines. | `""` |
+| `failed_jobs_history_limit`  | cronjob | The number of failed jobs to keep. | `5` |
+| `success_jobs_history_limit`  | cronjob | The number of successful jobs to keep. | `5` |
+| `image` | cronjob | The container image to use for the cronjob. | `quay.io/openshift/origin-cli` |
+| `image_tag` | cronjob | The container image tag to use for the cronjob. | `4.7` |

--- a/charts/cronjob-prune-tekton-pipelinerun/templates/cronjob.yaml
+++ b/charts/cronjob-prune-tekton-pipelinerun/templates/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
     template: cronjob-prune-tekton-pipelinerun
   name: {{ .Values.job_name }}
 spec:
-  schedule: "{{ .Values.schedule }}"
+  schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.success_jobs_history_limit }}
   concurrencyPolicy: Forbid
   jobTemplate:
@@ -19,14 +19,22 @@ spec:
             - name: kubectl
               image: {{ .Values.image }}:{{ .Values.image_tag }}
               env:
+                - name: PIPELINES
+                  value: {{ .Values.pipelines | quote }}
                 - name: NUM_TO_KEEP
-                  value: "{{ .Values.num_to_keep }}"
+                  value: {{ .Values.num_to_keep | quote }}
               command:
                 - /bin/bash
                 - -c
                 - |
-                    TO_DELETE="$(kubectl get pipelinerun -o jsonpath='{range .items[?(@.status.completionTime)]}{.status.completionTime}{" "}{.metadata.name}{"\n"}{end}' | sort | head -n -${NUM_TO_KEEP} | awk '{ print $2}')"
-                    test -n "$TO_DELETE" && kubectl delete pipelinerun ${TO_DELETE} || true
+                    PIPELINES=${PIPELINES:-$(kubectl get pipeline -A -ojsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}'|grep -vE '^default|^kube|^openshift')}
+                    for pipeline in $PIPELINES
+                    do
+                      NS=$(echo $pipeline | awk -F/ '{print $1}')
+                      PL_LABEL=$(echo $pipeline | awk -F/ '{print $2}')
+                      TO_DELETE=$(kubectl get pipelinerun -n $NS -l tekton.dev/pipeline=$PL_LABEL --ignore-not-found -o jsonpath='{range .items[?(@.status.completionTime)]}{.status.completionTime}{" "}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}' | sort | head -n -${NUM_TO_KEEP} | awk -F/ '{print $2}')
+                      test -n "$TO_DELETE" && kubectl delete pipelinerun ${TO_DELETE} -n ${NS} || true
+                    done
           serviceAccount: {{ .Values.job_service_account }}
           serviceAccountName: {{ .Values.job_service_account }}
           terminationGracePeriodSeconds: 60

--- a/charts/cronjob-prune-tekton-pipelinerun/values.yaml
+++ b/charts/cronjob-prune-tekton-pipelinerun/values.yaml
@@ -1,9 +1,10 @@
 namespace: labs-ci-cd
 job_name: cronjob-prune-tekton-pipelinerun
 job_service_account: tekton-pruner
+pipelines: ''
 num_to_keep: "10"
 failed_jobs_history_limit: "5"
 schedule: "*/30 * * * *"
 success_jobs_history_limit: "5"
 image: quay.io/openshift/origin-cli
-image_tag: 4.5
+image_tag: 4.7


### PR DESCRIPTION
#### What is this PR About?
Extend the Tekton pipelinerun prune job to support multiple pipelines and across namespaces.

#### How do we test this?
Deploy the Helm chart and test away

cc: @redhat-cop/casl
