### PR TITLE
cronjob_etcd_backup: Use mindepth + maxdepth params

### DIFF
--- a/charts/cronjob-etcd-backup/templates/CronJob.yml
+++ b/charts/cronjob-etcd-backup/templates/CronJob.yml
@@ -48,7 +48,7 @@ spec:
                 mkdir -pv /mnt/backup/$(date "+%F_%H%M%S") &&
                 cp -v /host/home/core/backup/* /mnt/backup/$(date "+%F_%H%M%S") &&
                 echo -e "\n\n---\nDelete persistent ETCD backups older then ${DAYS_TO_KEEP_PERSISTENT_ETCD_BACKUPS} days\n" &&
-                find /mnt/backup/* -type d -mtime +${DAYS_TO_KEEP_PERSISTENT_ETCD_BACKUPS} -exec rm -rv {} \; &&
+                find /mnt/backup/ -mindepth 1 -maxdepth 1 -type d -mtime +${DAYS_TO_KEEP_PERSISTENT_ETCD_BACKUPS} -exec rm -rv {} \; &&
                 echo -e '\n\n---\nList all etc backups\n' &&
                 ls -al /mnt/backup/*
               env:


### PR DESCRIPTION
#### What is this PR About?

The cronjob pod exists unsuccessful when it deletes old backups (sometimes). It depends on how find lists the directories to be passed to `rm -rv`. If it doesn't exist anymore, it will fail. 

Removing the "*" globbing and using min-/maxdepth params will find all dirs directly below /mnt/backup. So it will only call `rm -rv` once per directory.

Another workaround could be to add `-f` to `rm` which would ignore non-existent paths to remove.

#### How do we test this?
Check status and logs of finished CronJob pods.

cc: @redhat-cop/casl
