### PR TITLE
etcd-backup: modify README due to PSA

### DIFF
--- a/charts/cronjob-etcd-backup/README.md
+++ b/charts/cronjob-etcd-backup/README.md
@@ -9,10 +9,12 @@ that the etcd backup is moved to external storage via a PVC.
 
 ## Use
 
+**Please do not use OpenShift pre-fixed namespaces, this is not recommended and won't work in the future.**
+
 ### Manual
 Installs and tests the helm chart
 ```bash
-helm upgrade --install cronjob-etcd-backup ./cronjob-etcd-backup --namespace openshift-etcd-backup --create-namespace
+helm upgrade --install cronjob-etcd-backup ./cronjob-etcd-backup --namespace system-etcd-backup --create-namespace
 helm test cronjob-etcd-backup
 ```
 
@@ -24,11 +26,11 @@ are many ways. Here is a start if you don't already have an opinion.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: openshift-etcd-backup
+  name: system-etcd-backup
 spec:
   destination:
     name: ''
-    namespace: openshift-etcd-backup
+    namespace: system-etcd-backup
     server: 'https://kubernetes.default.svc'
   source:
     path: charts/cronjob-etcd-backup


### PR DESCRIPTION
#### What is this PR About?

Discourages customers to use openshift-prefixed-namespaces.

Creating an OpenShift pre-fixed namespace will break in the future, if the namespace is not labeled manually.
With the introduction of [PodSecurityAdmission (PSA)](https://kubernetes.io/docs/concepts/security/pod-security-admission/) namespaces will have the ability to define the security level namespace-wide.
As SCCs are more fine-grained, we defined a [label syncer controller](https://docs.openshift.com/container-platform/4.14/authentication/understanding-and-managing-pod-security-admission.html) that takes care of customer workloads and sets the PSA values accordingly.
This doesn't happen for OpenShift pre-fixed namespaces as we expect that every Team working on OpenShift is defining their security posture consciously.

In addition, [Helm doesn't support to create namespaces with labels](https://github.com/helm/helm/issues/11194). 

#### How do we test this?

```bash
kubectl get namespace system-etcd-backup -o jsonpath='{.metadata.labels}' | grep 'pod-security.kubernetes.io/'
```

Should return labels that are set to `privileged`.

cc: @redhat-cop/casl
